### PR TITLE
Hotfix/automated groups

### DIFF
--- a/web/concrete/single_pages/dashboard/users/add_group.php
+++ b/web/concrete/single_pages/dashboard/users/add_group.php
@@ -142,6 +142,11 @@ $registeredGroupNode = GroupTreeNode::getTreeNodeByGroupID(REGISTERED_GROUP_ID);
                 <span><?=t('When the "Check Automated Groups" Job runs.')?></span>
             </label>
         </div>
+        <div class="alert alert-info">
+            <?
+            print t('For custom automated group actions, make sure an automation group controller exists.');
+            ?>
+        </div>
 	</div>
 </div>
 

--- a/web/concrete/single_pages/dashboard/users/groups.php
+++ b/web/concrete/single_pages/dashboard/users/groups.php
@@ -118,7 +118,7 @@ if (isset($group)) { ?>
     		<div class="alert alert-info">
     			<?
     			$path = $group->getGroupAutomationControllerClass();
-    			print t('Make sure an automation group controller exists at %s', $path);
+    			print t('For custom automated group actions, make sure an automation group controller exists at %s', $path);
     			?>
     		</div>
     	</div>

--- a/web/concrete/src/User/Group/AutomatedGroup/DefaultAutomation.php
+++ b/web/concrete/src/User/Group/AutomatedGroup/DefaultAutomation.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Concrete\Core\User\Group\AutomatedGroup;
+use Concrete\Core\User\User;
+use Concrete\Core\User\Group\GroupAutomationController;
+
+class DefaultAutomation extends GroupAutomationController {
+
+    /**
+     * Return true to automatically enter the current ux into the group
+     */
+    public function check(User $ux) {
+        return true;
+    }
+
+}

--- a/web/concrete/src/User/Group/Group.php
+++ b/web/concrete/src/User/Group/Group.php
@@ -366,7 +366,11 @@ class Group extends Object implements \Concrete\Core\Permission\ObjectInterface
     public function getGroupAutomationController()
     {
         $class = $this->getGroupAutomationControllerClass();
-        $c = \Core::make($class, array($this));
+        try {
+            $c = \Core::make($class, array($this));
+        } catch(\ReflectionException $e) {
+            $c = \Core::make(core_class('\\Core\\User\\Group\\AutomatedGroup\\DefaultAutomation'), array($this));
+        }
         return $c;
     }
 


### PR DESCRIPTION
If you added a group that had any form of automation, and you did not create a automation controller c5 would throw exceptions trying to load that class.

This pull request adds a default controller that will add the user to the group if the class does not exist.