### PR TITLE
Suggested tweaks to toolbar button labels

### DIFF
--- a/web/concrete/elements/page_controls_footer.php
+++ b/web/concrete/elements/page_controls_footer.php
@@ -208,7 +208,7 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
                title="<?= t('Page Design, Location, Attributes and Settings') ?>">
                 <i class="fa fa-cog"></i>
                 <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-settings">
-                    <?= tc('toolbar', 'Settings') ?>
+                    <?= tc('toolbar', 'Page Settings') ?>
                 </span>
             </a>
         </li>
@@ -224,7 +224,7 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
                    title="<?= t('Add Content to The Page') ?>">
                     <i class="fa fa-plus"></i>
                     <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-add">
-                        <?= tc('toolbar', 'Add') ?>
+                        <?= tc('toolbar', 'Add Content') ?>
                     </span>
                 </a>
             <? } else { ?>
@@ -232,7 +232,7 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
                    title="<?= t('Add Content to The Page') ?>">
                     <i class="fa fa-plus"></i>
                     <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-add">
-                        <?= tc('toolbar', 'Add') ?>
+                        <?= tc('toolbar', 'Add Content') ?>
                     </span>
                 </a>
             <? } ?>
@@ -287,7 +287,7 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
                                             data-launch-panel="sitemap">
                 <i class="fa fa-files-o"></i>
                 <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-add-page">
-                    <?= tc('toolbar', 'Add Page') ?>
+                    <?= tc('toolbar', 'Pages') ?>
                 </span>
             </a>
 

--- a/web/concrete/themes/dashboard/elements/header.php
+++ b/web/concrete/themes/dashboard/elements/header.php
@@ -87,7 +87,7 @@ $large_font = !!Config::get('concrete.accessibility.toolbar_large_font');
             <a href="#" data-panel-url="<?=URL::to('/system/panels/sitemap')?>" data-launch-panel="sitemap">
                 <i class="fa fa-files-o"></i>
                 <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-add-page">
-                    <?= tc('toolbar', 'Add Page') ?>
+                    <?= tc('toolbar', 'Pages') ?>
                 </span>
             </a>
         </li>


### PR DESCRIPTION
This is a suggestion for more meaningful labels for the main toolbar buttons, more inline with their tooltips and purpose.

‘Add Page’ change to ‘Pages’  - This panel also has a very handy sitemap in it, so it’s not just about adding pages, it’s about navigating the pages of your site.

‘Settings’ change to ‘Page Settings’ - this button is referring specifically to the current page, whereas the word Settings seems too broad and could be interpreted to mean site settings.

‘Add’ to ‘Add Content’ - this button is always about adding blocks (or stacks) to a page, but the word add by itself could imply other things. Adding the word Content gives more context.

I’m sorry to be pedantic about these labels, but since these labels are about improving accessibility they should be as meaningful as possible.