### PR TITLE
allowed the add block panel to be pinned down

### DIFF
--- a/web/concrete/elements/page_controls_header.php
+++ b/web/concrete/elements/page_controls_header.php
@@ -52,7 +52,7 @@ if (!$dh->inDashboard()) {
 	ConcretePanelManager.register({'identifier': 'page', url: '{$panelPage}'});
 	ConcretePanelManager.register({'identifier': 'sitemap', 'position': 'right', url: '{$panelSitemap}'});
 	ConcretePanelManager.register({'identifier': 'multilingual', 'position': 'right', url: '{$panelMultilingual}'});
-	ConcretePanelManager.register({'identifier': 'add-block', 'translucent': false, 'position': 'left', url: '{$panelAdd}'});
+	ConcretePanelManager.register({'identifier': 'add-block', 'translucent': false, 'position': 'left', url: '{$panelAdd}', pinable: true});
 	ConcretePanelManager.register({'identifier': 'check-in', 'position': 'left', url: '{$panelCheckIn}'});
 	ConcreteToolbar.start();
 	{$startEditMode}

--- a/web/concrete/js/build/core/app/edit-mode/blocktype.js
+++ b/web/concrete/js/build/core/app/edit-mode/blocktype.js
@@ -86,6 +86,9 @@
                             _.defer(function () {
                                 my.getEditMode().scanBlocks();
                             });
+
+                            var panel = ConcretePanelManager.getByIdentifier('add-block');
+                            if ( panel && panel.pinned() ) panel.show();
                         });
                 });
             } else if (is_inline) {
@@ -111,6 +114,10 @@
                                 placeholder: placeholder
                             });
                         });
+                    },
+                    onDestroy: function() {
+                        var panel = ConcretePanelManager.getByIdentifier('add-block');
+                        if ( panel && panel.pinned() ) panel.show();
                     },
                     width: parseInt(elem.data('dialog-width'), 10),
                     height: parseInt(elem.data('dialog-height'), 10) + 20,

--- a/web/concrete/js/build/core/app/edit-mode/editmode.js
+++ b/web/concrete/js/build/core/app/edit-mode/editmode.js
@@ -167,6 +167,9 @@
                 my.bindEvent('EditModeExitInlineSaved', function (e) {
                     Concrete.event.unbind(e);
                     saved = true;
+
+                    var panel = ConcretePanelManager.getByIdentifier('add-block');
+                    if ( panel && panel.pinned() ) panel.show();
                 });
                 my.bindEvent('EditModeExitInline', function (e) {
                     Concrete.event.unsubscribe(e);
@@ -176,6 +179,9 @@
                     $('#a' + area.getId() + '-bt' + btID).remove();
                     my.destroyInlineEditModeToolbars();
                     ConcreteEvent.fire('EditModeExitInlineComplete');
+
+                    var panel = ConcretePanelManager.getByIdentifier('add-block');
+                    if ( panel && panel.pinned() ) panel.show();
                 });
                 $.ajax({
                     type: 'GET',

--- a/web/concrete/js/build/core/app/panels.js
+++ b/web/concrete/js/build/core/app/panels.js
@@ -11,6 +11,10 @@ function ConcretePanel(options) {
 
     this.pinned = function() { return this.isPinned; }
 
+    this.willBePinned = function() { return this.isOpen && !this.isPinned; }
+
+    this.isPinable = function() { return this.options.pinable; }
+
     this.getPositionClass = function () {
         var ccm_class;
         switch (options.position) {

--- a/web/concrete/js/build/core/app/panels.js
+++ b/web/concrete/js/build/core/app/panels.js
@@ -7,6 +7,9 @@ function ConcretePanel(options) {
     this.options = options;
     this.isOpen = false;
     this.detail = false;
+    this.isPinned = false;
+
+    this.pinned = function() { return this.isPinned; }
 
     this.getPositionClass = function () {
         var ccm_class;
@@ -75,7 +78,18 @@ function ConcretePanel(options) {
 
     this.toggle = function () {
         if (this.isOpen) {
-            this.hide();
+            if (this.options.pinable )
+            {
+                if (!this.isPinned )
+                {
+                    this.isPinned = true;
+                }
+                else
+                {
+                    this.isPinned = false;
+                    this.hide();
+                }
+            } else this.hide();
         } else {
             this.show();
         }

--- a/web/concrete/js/build/core/app/toolbar.js
+++ b/web/concrete/js/build/core/app/toolbar.js
@@ -81,9 +81,16 @@ var ConcreteToolbar = function() {
         });
 
 		$('[data-launch-panel]').unbind().on('click', function() {
-			var panelID = $(this).attr('data-launch-panel');
-			$(this).toggleClass('ccm-launch-panel-loading');
+            var $this = $(this);
+			var panelID = $this.attr('data-launch-panel');
 			var panel = ConcretePanelManager.getByIdentifier(panelID);
+            if ( !panel.willBePinned() ) $this.toggleClass('ccm-launch-panel-loading');
+            
+            if ( panel.isPinable() ) 
+            {
+                var parent = $($this.parent());
+                if ( panel.willBePinned() || panel.pinned() ) parent.toggleClass("ccm-toolbar-page-edit-mode-active");
+            }
 			panel.toggle();
 			return false;
 		});


### PR DESCRIPTION
Regarding issue #1688

- Clicking on the add block button opens it (but does not lock it)
- Clicking a second times locks it down.
- Clicking a third time closes it

If the panel is not locked (pinned) then no change from previous behavior.

If the panel is pinned, it is reopened after a block had been added (or its add form closed/cancel).

Tell me how you guys feel about it.