### PR TITLE
Allow theme to be set to false

### DIFF
--- a/web/concrete/src/Page/Controller/PageController.php
+++ b/web/concrete/src/Page/Controller/PageController.php
@@ -56,7 +56,7 @@ class PageController extends Controller {
     }
 
     public function getTheme() {
-        if (!$this->theme) {
+        if ($this->theme === null) {
             $theme = parent::getTheme();
             if (!$theme) {
                 $theme = $this->c->getCollectionThemeObject();


### PR DESCRIPTION
I changed this if statement to check if theme is null. This allows for `$this->theme = false` to be used in an action to disable the theme for just that action instead of having to override `getTheme()` and disable it for the entire controller.