### PR TITLE
Fix localization

### DIFF
--- a/web/concrete/src/Localization/Localization.php
+++ b/web/concrete/src/Localization/Localization.php
@@ -74,11 +74,11 @@ class Localization
             }
             // Site language files
             $languageDir = DIR_LANGUAGES_SITE_INTERFACE;
-            if (!is_dir($languageDir)) {
+            if (!is_file("$languageDir/$locale.mo")) {
                 $languageDir = '';
             }
             if(strlen($languageDir)) {
-                $this->translate->addTranslationFilePattern('gettext', DIR_LANGUAGES_SITE_INTERFACE, $locale . '.mo');
+                $this->translate->addTranslationFilePattern('gettext', $languageDir, $locale . '.mo');
             }
             // Package language files
             $pkgList = CacheLocal::getEntry('pkgList', 1);

--- a/web/concrete/src/Localization/Localization.php
+++ b/web/concrete/src/Localization/Localization.php
@@ -1,5 +1,6 @@
 <?php
 namespace Concrete\Core\Localization;
+
 use Config;
 use Concrete\Core\Cache\Adapter\ZendCacheDriver;
 use Loader;
@@ -19,7 +20,6 @@ class Localization
     {
         if (null === self::$loc) {
             self::$loc = new self();
-
         }
 
         return self::$loc;
@@ -59,6 +59,7 @@ class Localization
                 unset($this->translate);
             }
             PunicData::setDefaultLocale($locale);
+
             return;
         }
         if (is_dir(DIR_LANGUAGES . '/' . $locale)) {

--- a/web/concrete/src/Localization/Localization.php
+++ b/web/concrete/src/Localization/Localization.php
@@ -3,7 +3,7 @@ namespace Concrete\Core\Localization;
 
 use Config;
 use Concrete\Core\Cache\Adapter\ZendCacheDriver;
-use Loader;
+use Core;
 use Events;
 use \Zend\I18n\Translator\Translator;
 use \Punic\Data as PunicData;
@@ -117,7 +117,7 @@ class Localization
     public static function getAvailableInterfaceLanguages()
     {
         $languages = array();
-        $fh = Loader::helper('file');
+        $fh = Core::make('helper/file');
 
         if (file_exists(DIR_LANGUAGES)) {
             $contents = $fh->getDirectoryContents(DIR_LANGUAGES);

--- a/web/concrete/src/Localization/Localization.php
+++ b/web/concrete/src/Localization/Localization.php
@@ -82,9 +82,6 @@ class Localization
             }
             // Package language files
             $pkgList = CacheLocal::getEntry('pkgList', 1);
-            if(!is_null($pkgList)) {
-                $pkgList = $pkgList;
-            }
             if(is_object($pkgList)) {
                 foreach ($pkgList->getPackages() as $pkg) {
                     $pkg->setupPackageLocalization($locale, $this->translate);

--- a/web/concrete/src/Localization/Localization.php
+++ b/web/concrete/src/Localization/Localization.php
@@ -58,37 +58,38 @@ class Localization
             if (isset($this->translate)) {
                 unset($this->translate);
             }
-        }
-        else {
+        } else {
             $this->translate = new Translator();
+            $this->translate->setLocale($locale);
+            $this->translate->setCache(self::getCache());
             // Core language files
-            $languageDir = DIR_LANGUAGES . '/' . $locale;
-            if (!is_dir($languageDir)) {
-                $languageDir = DIR_LANGUAGES_CORE . '/' . $locale;
-                if (!is_dir($languageDir)) {
-                    $languageDir = '';
+            $languageFile = DIR_LANGUAGES . "/$locale/LC_MESSAGES/messages.mo";
+            if (!is_file($languageFile)) {
+                $languageFile = DIR_LANGUAGES_CORE . "/$locale/LC_MESSAGES/messages.mo";
+                if (!is_file($languageFile)) {
+                    $languageFile = '';
                 }
             }
-            if(strlen($languageDir)) {
-                $this->translate->addTranslationFilePattern('gettext', $languageDir, 'LC_MESSAGES/messages.mo');
+            if (strlen($languageFile)) {
+                $this->translate->addTranslationFile('gettext', $languageFile);
             }
             // Site language files
-            $languageDir = DIR_LANGUAGES_SITE_INTERFACE;
-            if (!is_file("$languageDir/$locale.mo")) {
-                $languageDir = '';
-            }
-            if(strlen($languageDir)) {
-                $this->translate->addTranslationFilePattern('gettext', $languageDir, $locale . '.mo');
+            if (Config::get('concrete.multilingual.enabled')) {
+                $languageFile = DIR_LANGUAGES_SITE_INTERFACE . "/$locale.mo";
+                if (!is_file($languageFile)) {
+                    $languageFile = '';
+                }
+                if (strlen($languageFile)) {
+                    $this->translate->addTranslationFile('gettext', $languageFile);
+                }
             }
             // Package language files
             $pkgList = CacheLocal::getEntry('pkgList', 1);
-            if(is_object($pkgList)) {
+            if (is_object($pkgList)) {
                 foreach ($pkgList->getPackages() as $pkg) {
                     $pkg->setupPackageLocalization($locale, $this->translate);
                 }
             }
-            $this->translate->setLocale($locale);
-            $this->translate->setCache(self::getCache());
         }
         PunicData::setDefaultLocale($locale);
         $event = new \Symfony\Component\EventDispatcher\GenericEvent();

--- a/web/concrete/src/Multilingual/Service/Detector.php
+++ b/web/concrete/src/Multilingual/Service/Detector.php
@@ -93,32 +93,8 @@ class Detector
 
         $locale = $ms->getLocale();
 
-
-        // change core language to translate e.g. core blocks/themes
         if (strlen($locale)) {
             \Localization::changeLocale($locale);
-        }
-
-        // site translations
-        if (is_dir(DIR_LANGUAGES_SITE_INTERFACE)) {
-            if (file_exists(DIR_LANGUAGES_SITE_INTERFACE . '/' . $locale . '.mo')) {
-                $loc = \Localization::getInstance();
-                $loc->addSiteInterfaceLanguage($locale);
-            }
-        }
-
-        // add package translations
-        if (strlen($locale)) {
-            $ms = Section::getByLocale($locale);
-            if ($ms instanceof Section) {
-                $pl = PackageList::get();
-                $installed = $pl->getPackages();
-                foreach ($installed as $pkg) {
-                    if ($pkg instanceof Package) {
-                        $pkg->setupPackageLocalization($ms->getLocale());
-                    }
-                }
-            }
         }
     }
 }

--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -92,23 +92,49 @@ class Package extends Object
         return $dirp . '/' . $this->pkgHandle;
     }
 
-    public function getPackageID() {return $this->pkgID;}
-    public function getPackageName() {return t($this->pkgName);}
-    public function getPackageDescription() {return t($this->pkgDescription);}
-    public function getPackageHandle() {return $this->pkgHandle;}
+    public function getPackageID()
+    {
+        return $this->pkgID;
+    }
+
+    public function getPackageName()
+    {
+        return t($this->pkgName);
+    }
+
+    public function getPackageDescription()
+    {
+        return t($this->pkgDescription);
+    }
+
+    public function getPackageHandle()
+    {
+        return $this->pkgHandle;
+    }
 
     /**
-	 * Gets the date the package was added to the system,
-	 * @return string date formated like: 2009-01-01 00:00:00
-	*/
+     * Gets the date the package was added to the system,
+     * @return string date formated like: 2009-01-01 00:00:00
+    */
     public function getPackageDateInstalled()
     {
         return $this->pkgDateInstalled;
     }
 
-    public function getPackageVersion() {return $this->pkgVersion;}
-    public function getPackageVersionUpdateAvailable() {return $this->pkgAvailableVersion;}
-    public function isPackageInstalled() { return $this->pkgIsInstalled;}
+    public function getPackageVersion()
+    {
+        return $this->pkgVersion;
+    }
+
+    public function getPackageVersionUpdateAvailable()
+    {
+        return $this->pkgAvailableVersion;
+    }
+
+    public function isPackageInstalled()
+    {
+        return $this->pkgIsInstalled;
+    }
 
     public function getChangelogContents()
     {
@@ -122,9 +148,9 @@ class Package extends Object
     }
 
     /**
-	 * Returns the currently installed package version.
-	 * NOTE: This function only returns a value if getLocalUpgradeablePackages() has been called first!
-	 */
+     * Returns the currently installed package version.
+     * NOTE: This function only returns a value if getLocalUpgradeablePackages() has been called first!
+     */
     public function getPackageCurrentlyInstalledVersion()
     {
         return $this->pkgCurrentVersion;
@@ -190,37 +216,36 @@ class Package extends Object
         unset($platform);
 
         /*
-		$schema = Database::getADOSChema();
-		$sql = $schema->ParseSchema($xmlFile);
+        $schema = Database::getADOSChema();
+        $sql = $schema->ParseSchema($xmlFile);
 
-		$db->IgnoreErrors($handler);
+        $db->IgnoreErrors($handler);
 
-		if (!$sql) {
-			$result->message = $db->ErrorMsg();
-			return $result;
-		}
+        if (!$sql) {
+            $result->message = $db->ErrorMsg();
+            return $result;
+        }
 
-		$r = $schema->ExecuteSchema();
+        $r = $schema->ExecuteSchema();
 
 
-		if ($dbLayerErrorMessage != '') {
-			$result->message = $dbLayerErrorMessage;
-			return $result;
-		} if (!$r) {
-			$result->message = $db->ErrorMsg();
-			return $result;
-		}
+        if ($dbLayerErrorMessage != '') {
+            $result->message = $dbLayerErrorMessage;
+            return $result;
+        } if (!$r) {
+            $result->message = $db->ErrorMsg();
+            return $result;
+        }
 
-		$result->result = true;
+        $result->result = true;
 
-		$db->CacheFlush();
-		*/
+        $db->CacheFlush();
+        */
 
         $result = new \stdClass();
         $result->result = false;
 
         return $result;
-
     }
 
     public static function getClass($pkgHandle)
@@ -239,15 +264,16 @@ class Package extends Object
             }
             $item->set($cl);
         }
+
         return clone $cl;
     }
 
     /**
-	 * Loads package translation files into zend translate
-	 * @param string $locale
-	 * @param string $key
-	 * @return void
-	*/
+     * Loads package translation files into zend translate
+     * @param string $locale
+     * @param string $key
+     * @return void
+    */
     public function setupPackageLocalization($locale = null, $key = null)
     {
         $translate = Localization::getTranslate();
@@ -268,8 +294,8 @@ class Package extends Object
     }
 
     /**
-	 * Returns an array of package items (e.g. blocks, themes)
-	 */
+     * Returns an array of package items (e.g. blocks, themes)
+     */
     public function getPackageItems()
     {
         $items = array();
@@ -315,10 +341,10 @@ class Package extends Object
     }
 
     /** Returns the display name of a category of package items (localized and escaped accordingly to $format)
-	* @param string $categoryHandle The category handle
-	* @param string $format = 'html' Escape the result in html format (if $format is 'html'). If $format is 'text' or any other value, the display name won't be escaped.
-	* @return string
-	*/
+    * @param string $categoryHandle The category handle
+    * @param string $format = 'html' Escape the result in html format (if $format is 'html'). If $format is 'text' or any other value, the display name won't be escaped.
+    * @return string
+    */
     public static function getPackageItemsCategoryDisplayName($categoryHandle, $format = 'html')
     {
         switch ($categoryHandle) {
@@ -438,7 +464,6 @@ class Package extends Object
             $akc = AttributeKeyCategory::getByID($item->getAttributeKeyCategoryID());
 
             return t(' %s (%s)', $txt->unhandle($item->getAttributeKeyHandle()), $txt->unhandle($akc->getAttributeKeyCategoryHandle()));
-
         } elseif ($item instanceof UserPointAction) {
             return $item->getUserPointActionName();
         } elseif ($item instanceof SystemCaptchaLibrary) {
@@ -463,8 +488,8 @@ class Package extends Object
     }
 
     /**
-	 * Uninstalls the package. Removes any blocks, themes, or pages associated with the package.
-	 */
+     * Uninstalls the package. Removes any blocks, themes, or pages associated with the package.
+     */
     public function uninstall()
     {
         $db = Loader::db();
@@ -563,7 +588,6 @@ class Package extends Object
     public function swapContent($options)
     {
         if ($this->validateClearSiteContents($options)) {
-
             \Core::make('cache/request')->disable();
 
             $pl = new PageList();
@@ -597,7 +621,6 @@ class Package extends Object
 
             // now we add in any files that this package has
             if (is_dir($this->getPackagePath() . '/content_files')) {
-
                 $fh = new FileImporter();
                 $contents = Loader::helper('file')->getDirectoryContents($this->getPackagePath() . '/content_files');
 
@@ -682,10 +705,10 @@ class Package extends Object
     }
 
     /*
-	 * Returns a path to where the packages files are located.
-	 * @access public
-	 * @return string $path
-	 */
+     * Returns a path to where the packages files are located.
+     * @access public
+     * @return string $path
+     */
 
     public function getPackagePath()
     {
@@ -696,10 +719,10 @@ class Package extends Object
     }
 
     /**
-	 * returns a Package object for the given package id, null if not found
-	 * @param int $pkgID
-	 * @return Package
-	 */
+     * returns a Package object for the given package id, null if not found
+     * @param int $pkgID
+     * @return Package
+     */
     public static function getByID($pkgID)
     {
         $db = Loader::db();
@@ -708,16 +731,17 @@ class Package extends Object
             $pkg = static::getClass($row['pkgHandle']);
             if ($pkg instanceof Package) {
                 $pkg->setPropertiesFromArray($row);
+
                 return $pkg;
             }
         }
     }
 
     /**
-	 * returns a Package object for the given package handle, null if not found
-	 * @param string $pkgHandle
-	 * @return Package
-	 */
+     * returns a Package object for the given package handle, null if not found
+     * @param string $pkgHandle
+     * @return Package
+     */
     public static function getByHandle($pkgHandle)
     {
         $db = Loader::db();
@@ -777,8 +801,8 @@ class Package extends Object
     }
 
     /**
-	 * @return Package
-	 */
+     * @return Package
+     */
     public function install()
     {
         $cl = \Concrete\Core\Foundation\ClassLoader::getInstance();
@@ -852,9 +876,9 @@ class Package extends Object
     }
 
     /**
-	 * Returns an array of packages that have newer versions in the local packages directory
-	 * than those which are in the Packages table. This means they're ready to be upgraded
-	 */
+     * Returns an array of packages that have newer versions in the local packages directory
+     * than those which are in the Packages table. This means they're ready to be upgraded
+     */
     public static function getLocalUpgradeablePackages()
     {
         $packages = Package::getAvailablePackages(false);
@@ -888,8 +912,8 @@ class Package extends Object
     }
 
     /**
-	 * moves the current package's directory to the trash directory renamed with the package handle and a date code.
-	*/
+     * moves the current package's directory to the trash directory renamed with the package handle and a date code.
+    */
     public function backup()
     {
         // you can only backup root level packages.
@@ -910,9 +934,9 @@ class Package extends Object
     }
 
     /**
-	 * if a packate was just backed up by this instance of the package object and the packages/package handle directory doesn't exist, this will restore the
-	 * package from the trash
-	*/
+     * if a packate was just backed up by this instance of the package object and the packages/package handle directory doesn't exist, this will restore the
+     * package from the trash
+    */
     public function restore()
     {
         if (strlen($this->backedUpFname) && is_dir($this->backedUpFname) && !is_dir(DIR_PACKAGES . '/' . $this->pkgHandle)) {
@@ -956,5 +980,4 @@ class Package extends Object
 
         return $packages;
     }
-
 }

--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -283,8 +283,9 @@ class Package extends Object
             if (!isset($locale) || !strlen($locale)) {
                 $locale = Localization::activeLocale();
             }
-            if (file_exists($path . '/' . $locale . '/LC_MESSAGES/messages.mo')) {
-                $translate->addTranslationFilePattern('gettext', $path . '/' . $locale, '/LC_MESSAGES/messages.mo');
+            $languageFile = "$path/$locale/LC_MESSAGES/messages.mo";
+            if (is_file($languageFile)) {
+                $translate->addTranslationFile('gettext', $languageFile);
             }
         }
     }

--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -115,7 +115,7 @@ class Package extends Object
     /**
      * Gets the date the package was added to the system,
      * @return string date formated like: 2009-01-01 00:00:00
-    */
+     */
     public function getPackageDateInstalled()
     {
         return $this->pkgDateInstalled;
@@ -270,23 +270,19 @@ class Package extends Object
 
     /**
      * Loads package translation files into zend translate
-     * @param string $locale
-     * @param string $key
-     * @return void
-    */
-    public function setupPackageLocalization($locale = null, $key = null)
+     * @param string $locale = null The identifier of the locale to activate (used to build the language file path). If empty we'll use currently active locale.
+     * @param \Zend\I18n\Translator\Translator|string $translate = 'current' The Zend Translator instance that holds the translations (set to 'current' to use the current one)
+     */
+    public function setupPackageLocalization($locale = null, $translate = 'current')
     {
-        $translate = Localization::getTranslate();
+        if ($translate === 'current') {
+            $translate = Localization::getTranslate();
+        }
         if (is_object($translate)) {
             $path = $this->getPackagePath() . '/' . DIRNAME_LANGUAGES;
             if (!isset($locale) || !strlen($locale)) {
                 $locale = Localization::activeLocale();
             }
-
-            if (!isset($key)) {
-                $key = $locale;
-            }
-
             if (file_exists($path . '/' . $locale . '/LC_MESSAGES/messages.mo')) {
                 $translate->addTranslationFilePattern('gettext', $path . '/' . $locale, '/LC_MESSAGES/messages.mo');
             }
@@ -341,10 +337,10 @@ class Package extends Object
     }
 
     /** Returns the display name of a category of package items (localized and escaped accordingly to $format)
-    * @param string $categoryHandle The category handle
-    * @param string $format = 'html' Escape the result in html format (if $format is 'html'). If $format is 'text' or any other value, the display name won't be escaped.
-    * @return string
-    */
+     * @param string $categoryHandle The category handle
+     * @param string $format = 'html' Escape the result in html format (if $format is 'html'). If $format is 'text' or any other value, the display name won't be escaped.
+     * @return string
+     */
     public static function getPackageItemsCategoryDisplayName($categoryHandle, $format = 'html')
     {
         switch ($categoryHandle) {
@@ -913,7 +909,7 @@ class Package extends Object
 
     /**
      * moves the current package's directory to the trash directory renamed with the package handle and a date code.
-    */
+     */
     public function backup()
     {
         // you can only backup root level packages.
@@ -936,7 +932,7 @@ class Package extends Object
     /**
      * if a packate was just backed up by this instance of the package object and the packages/package handle directory doesn't exist, this will restore the
      * package from the trash
-    */
+     */
     public function restore()
     {
         if (strlen($this->backedUpFname) && is_dir($this->backedUpFname) && !is_dir(DIR_PACKAGES . '/' . $this->pkgHandle)) {


### PR DESCRIPTION
I think that I finally managed to fix the localization stuff.
Now everything should be fine: callink Localization::changeLocale loads the core + package + site language files.
BTW, we've got some breaking change here. IMHO they're quite minor, but a feedback from the core team is needed:
1. I removed Localization::addSiteInterfaceLanguage: it's useless since changeLocale does everything that's needed
2. Package::setupPackageLocalization had an unused `$key` parameter. I replaced it with the `$translate` parameter that's needed by Localization::changeLocale.