### PR TITLE
[feature] Make fileset sortable by filename/title/date in dashboard

### DIFF
--- a/web/concrete/single_pages/dashboard/files/sets.php
+++ b/web/concrete/single_pages/dashboard/files/sets.php
@@ -1,6 +1,7 @@
 <?php defined('C5_EXECUTE') or die("Access Denied.");
 
 $ih = Core::make('helper/concrete/ui'); 
+$dh = Core::make('helper/date');
 
 ?>
 <?php if ($this->controller->getTask() == 'view_detail') { ?>
@@ -65,21 +66,30 @@ $ih = Core::make('helper/concrete/ui');
             <span class="help-block"><?=t('Click and drag to reorder the files in this set. New files added to this set will automatically be appended to the end.')?></span>
             <div class="ccm-spacer">&nbsp;</div>
 
-            <ul class="ccm-file-set-file-list  item-select-list">
+            <table class="ccm-search-results-table">
+                <thead>
+                    <th></th>
+                    <th><span><?=t('Thumbnail')?></span></th>
+                    <th data-sort="type"><span><?=t('Type')?></span></th>
+                    <th data-sort="title"><span><?=t('Title')?></span></th>
+                    <th data-sort="filename"><span><?=t('File name')?></span></th>
+                    <th data-sort="added"><span><?=t('Added')?></span></th>
+                </thead>
 
-            <?php foreach($files as $f) { ?>
+                <tbody class="ccm-file-set-file-list">
 
-                <li id="fID_<?=$f->getFileID()?>" class="">
-                    <div>
-                        <?=$f->getListingThumbnailImage()?>
-                        <input type="hidden" name="fsDisplayOrder[]" value="<?=$f->getFileID()?>" />
-                        <span style="word-wrap: break-word"><?=$f->getTitle()?></span>
-                    </div>
-                </li>
-
-            <?php } ?>
-
-            </ul>
+                    <?php foreach($files as $f) { ?>
+                        <tr id="fID_<?=$f->getFileID()?>" class="">
+                            <td><i class="fa fa-arrows-v"></i></td>
+                            <td ><?=$f->getListingThumbnailImage()?><input type="hidden" name="fsDisplayOrder[]" value="<?=$f->getFileID()?>" /></td>
+                            <td data-key="type" ><?=$f->getGenericTypetext()?>/<?=$f->getType()?></td>
+                            <td data-key="title"><?=$f->getTitle()?></td>
+                            <td data-key="filename"><?=$f->getFileName()?></td>
+                            <td data-key="added" data-sort="<?=$f->getDateAdded()->getTimestamp()?>" ><?=$dh->formatDateTime($f->getDateAdded()->getTimestamp())?></td>
+                        </tr>
+                    <?php } ?>
+                </tbody>
+            </table>
 		<?php } else { ?>
 			<div class="alert alert-info"><?=t('There are no files in this set.')?></div>
 		<?php } ?>
@@ -98,7 +108,23 @@ $ih = Core::make('helper/concrete/ui');
 	$(function() {
 		$(".ccm-file-set-file-list").sortable({
 			cursor: 'move',
-			opacity: 0.5
+            opacity: 0.5,
+            axis: 'y',
+            helper: function( evt, elem ) { 
+                var ret = $(elem).clone();
+                var i;
+                // copy the actual width of the elements
+
+                ret.width( elem.outerWidth() );
+                retChilds = $(ret.children());
+                elemChilds = $(elem.children());
+                
+                for ( i = 0; i < elemChilds.length; i++ ) 
+                    $(retChilds[i]).width( $(elemChilds[i]).outerWidth() );
+
+                return ret; 
+            },
+            placeholder: "ccm-file-set-file-placeholder"
 		});
 		
 	});
@@ -107,6 +133,8 @@ $ih = Core::make('helper/concrete/ui');
 	
 	<style type="text/css">
 	    .ccm-file-set-file-list:hover {cursor: move}
+        .ccm-file-set-file-placeholder { background-color: #ffd !important;  }
+        .ccm-file-set-file-placeholder td { background:transparent !important; }
 	</style>
 
 <?php } else { ?>

--- a/web/concrete/single_pages/dashboard/files/sets.php
+++ b/web/concrete/single_pages/dashboard/files/sets.php
@@ -121,7 +121,6 @@ $dh = Core::make('helper/date');
             var $parent = $(this).parent();
             var asc = $parent.hasClass( baseClass + 'asc' );
             var key = $this.attr('data-sort');
-            console.log( "should sort according to key ", key );
 
             ccmFileSetResetSortIcons();
             var sortableList = $('.ccm-file-set-file-list');

--- a/web/concrete/single_pages/dashboard/files/sets.php
+++ b/web/concrete/single_pages/dashboard/files/sets.php
@@ -70,10 +70,10 @@ $dh = Core::make('helper/date');
                 <thead>
                     <th></th>
                     <th><span><?=t('Thumbnail')?></span></th>
-                    <th data-sort="type"><span><?=t('Type')?></span></th>
-                    <th data-sort="title"><span><?=t('Title')?></span></th>
-                    <th data-sort="filename"><span><?=t('File name')?></span></th>
-                    <th data-sort="added"><span><?=t('Added')?></span></th>
+                    <th><a href="javascript:void(0)" class="sort-link" data-sort="type"    ><?=t('Type')?></a></th>
+                    <th><a href="javascript:void(0)" class="sort-link" data-sort="title"   ><?=t('Title')?></a></th>
+                    <th><a href="javascript:void(0)" class="sort-link" data-sort="filename"><?=t('File name')?></a></th>
+                    <th><a href="javascript:void(0)" class="sort-link" data-sort="added"   ><?=t('Added')?></a></th>
                 </thead>
 
                 <tbody class="ccm-file-set-file-list">
@@ -106,6 +106,44 @@ $dh = Core::make('helper/date');
 	<script type="text/javascript">
 
 	$(function() {
+        var baseClass="ccm-results-list-active-sort-"; // asc desc
+
+        function ccmFileSetResetSortIcons()
+        {
+            $(".ccm-search-results-table thead th").removeClass(baseClass + 'asc');
+            $(".ccm-search-results-table thead th").removeClass(baseClass + 'desc');
+            $(".ccm-search-results-table thead th a").css("color", "#93bfd5");
+        }
+
+        function ccmFileSetDoSort()
+        {
+            var $this = $(this);
+            var $parent = $(this).parent();
+            var asc = $parent.hasClass( baseClass + 'asc' );
+            var key = $this.attr('data-sort');
+            console.log( "should sort according to key ", key );
+
+            ccmFileSetResetSortIcons();
+            var sortableList = $('.ccm-file-set-file-list');
+            var listItems = $('tr', sortableList);
+
+            if ( asc ) $parent.addClass( baseClass + 'desc' );
+            else $parent.addClass( baseClass + 'asc' );
+
+            listItems.sort( function( a, b ) {
+                var aTD = $('td[data-key=' + key + ']', $(a) );
+                var bTD = $('td[data-key=' + key + ']', $(b) );
+
+                var aVal = typeof( aTD.attr('data-sort') ) == 'undefined' ? aTD.text().toUpperCase() : parseInt(aTD.attr('data-sort'));
+                var bVal = typeof( bTD.attr('data-sort') ) == 'undefined' ? bTD.text().toUpperCase() : parseInt(bTD.attr('data-sort'));
+
+                return asc ? (aVal < bVal) : (aVal > bVal);
+            });
+            sortableList.append(listItems);
+        }
+
+        $('.ccm-search-results-table thead th a.sort-link').click(ccmFileSetDoSort);
+
 		$(".ccm-file-set-file-list").sortable({
 			cursor: 'move',
             opacity: 0.5,
@@ -124,9 +162,13 @@ $dh = Core::make('helper/date');
 
                 return ret; 
             },
-            placeholder: "ccm-file-set-file-placeholder"
+            placeholder: "ccm-file-set-file-placeholder",
+            stop: function(e,ui) {
+                ccmFileSetResetSortIcons();
+            }
 		});
-		
+
+
 	});
 	
 	</script>

--- a/web/concrete/single_pages/dashboard/files/sets.php
+++ b/web/concrete/single_pages/dashboard/files/sets.php
@@ -1,31 +1,30 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
-<? $ih = Loader::helper('concrete/ui'); ?>
-<? if ($this->controller->getTask() == 'view_detail') { ?>
+<?php defined('C5_EXECUTE') or die("Access Denied.");
 
-	<?
-	$u=new User();
-	$delConfirmJS = t('Are you sure you want to permanently remove this file set?');
-	?>
+$ih = Core::make('helper/concrete/ui'); 
+
+?>
+<?php if ($this->controller->getTask() == 'view_detail') { ?>
+
 	<script type="text/javascript">
 		deleteFileSet = function() {
-			if (confirm('<?=$delConfirmJS?>')) { 
-				location.href = "<?=$view->url('/dashboard/files/sets', 'delete', $fs->getFileSetID(), Loader::helper('validation/token')->generate('delete_file_set'))?>";				
+			if (confirm('<?=t('Are you sure you want to permanently remove this file set?')?>')) { 
+				location.href = "<?=$view->url('/dashboard/files/sets', 'delete', $fs->getFileSetID(), Core::make('helper/validation/token')->generate('delete_file_set'))?>";
 			}
 		}
 	</script>
 
-	<?
+	<?php
 	$fsp = new Permissions($fs);
 	if ($fsp->canDeleteFileSet()) { ?>
 	<div class="ccm-dashboard-header-buttons">
 		<button class="btn btn-danger" onclick="deleteFileSet()"><?=t('Delete Set')?></button>
 	</div>
-	<? } ?>
+	<?php } ?>
 
 	<form method="post" class="form-horizontal" id="file_sets_edit" action="<?=$view->url('/dashboard/files/sets', 'file_sets_edit')?>">
 		<?=$validation_token->output('file_sets_edit');?>
 
-		<? print Loader::helper('concrete/ui')->tabs(array(
+		<?= $ih->tabs(array(
 			array('details', t('Details'), true),
 			array('files', t('Files in Set'))
 		));?>
@@ -37,48 +36,38 @@
                 <?=$form->text('file_set_name',$fs->fsName, array('class' => 'span5'));?>
 			</div>
 
-			<?
-			if (Config::get('concrete.permissions.model') != 'simple') {
-				if ($fsp->canEditFileSetPermissions()) { ?>
+            <?php if (Config::get('concrete.permissions.model') != 'simple' && $fsp->canEditFileSetPermissions()) { ?>
 			
-                    <div class="form-group">
-                        <div class="checkbox">
-                            <label class="checkbox"><?=$form->checkbox('fsOverrideGlobalPermissions', 1, $fs->overrideGlobalPermissions())?> <?=t('Enable custom permissions for this file set.')?></label>
-                        </div>
+                <div class="form-group">
+                    <div class="checkbox">
+                        <label class="checkbox"><?=$form->checkbox('fsOverrideGlobalPermissions', 1, $fs->overrideGlobalPermissions())?> <?=t('Enable custom permissions for this file set.')?></label>
                     </div>
+                </div>
 
-                    <div id="ccm-permission-list-form" <? if (!$fs->overrideGlobalPermissions()) { ?> style="display: none" <? } ?>>
-
-                    <? Loader::element('permission/lists/file_set', array("fs" => $fs)); ?>
-
-                    </div>
-				<? } 
+                <div id="ccm-permission-list-form" <?= !$fs->overrideGlobalPermissions() ? 'style="display: none"' : ''?> >
+                    <?php Loader::element('permission/lists/file_set', array("fs" => $fs)); ?>
+                </div>
+            <?php } ?>
 			
-			}
-
-			?>
-			
-
-			<?php echo $form->hidden('fsID',$fs->getFileSetID()); ?>
+			<?= $form->hidden('fsID',$fs->getFileSetID()); ?>
 			
 		</div>
 
 		<div class="ccm-tab-content" id="ccm-tab-content-files">
-		<?
-		
+		<?php
 		$fl = new FileList();
 		$fl->filterBySet($fs);
 		$fl->sortByFileSetDisplayOrder();
 		$files = $fl->get();
-		if (count($files) > 0) { ?>
+        if (count($files) > 0) { 
+        ?>
 
             <span class="help-block"><?=t('Click and drag to reorder the files in this set. New files added to this set will automatically be appended to the end.')?></span>
             <div class="ccm-spacer">&nbsp;</div>
 
             <ul class="ccm-file-set-file-list  item-select-list">
 
-            <?
-            foreach($files as $f) { ?>
+            <?php foreach($files as $f) { ?>
 
                 <li id="fID_<?=$f->getFileID()?>" class="">
                     <div>
@@ -88,17 +77,17 @@
                     </div>
                 </li>
 
-            <? } ?>
+            <?php } ?>
 
             </ul>
-		<? } else { ?>
+		<?php } else { ?>
 			<div class="alert alert-info"><?=t('There are no files in this set.')?></div>
-		<? } ?>
+		<?php } ?>
 		</div>
 		<div class="ccm-dashboard-form-actions-wrapper">
 		<div class="ccm-dashboard-form-actions">
 			<a href="<?=View::url('/dashboard/files/sets')?>" class="btn btn-default pull-left"><?=t('Cancel')?></a>
-			<?=Loader::helper("form")->submit('save', t('Save'), array('class' => 'btn btn-primary pull-right'))?>
+			<?=Core::make("helper/form")->submit('save', t('Save'), array('class' => 'btn btn-primary pull-right'))?>
 		</div>
 		</div>
 	</form>
@@ -131,7 +120,7 @@
                     <div class="ccm-search-field-content">
                         <div class="ccm-search-main-lookup-field">
                             <i class="fa fa-search"></i>
-				            <?=$form->search('fsKeywords', Loader::helper('text')->entities($_REQUEST['fsKeywords']), array('placeholder' => t('File Set Name')))?>
+				            <?=$form->search('fsKeywords', \Core::make('helper/text')->entities($_REQUEST['fsKeywords']), array('placeholder' => t('File Set Name')))?>
                             <button type="submit" class="ccm-search-field-hidden-submit" tabindex="-1"><?=t('Search')?></button>
                         </div>
                     </div>
@@ -142,8 +131,8 @@
                     <?=$form->label('fsType', t('Type'))?>
                     <div class="ccm-search-field-content">
                         <select id="fsType" class="form-control" name="fsType" style="width: 200px; float: right">
-                        <option value="<?=FileSet::TYPE_PUBLIC?>" <? if ($fsType != FileSet::TYPE_PRIVATE) { ?> selected <? } ?>><?=t('Public Sets')?></option>
-                        <option value="<?=FileSet::TYPE_PRIVATE?>" <? if ($fsType == FileSet::TYPE_PRIVATE) { ?> selected <? } ?>><?=t('My Sets')?></option>
+                        <option value="<?=FileSet::TYPE_PUBLIC?>" <?php if ($fsType != FileSet::TYPE_PRIVATE) { ?> selected <?php } ?>><?=t('Public Sets')?></option>
+                        <option value="<?=FileSet::TYPE_PRIVATE?>" <?php if ($fsType == FileSet::TYPE_PRIVATE) { ?> selected <?php } ?>><?=t('My Sets')?></option>
                         </select>
                     </div>
                 </div>
@@ -167,28 +156,28 @@
 	</style>
 
     <section style="margin-right: 20px">
-	<? if (count($fileSets) > 0) { ?>
+	<?php if (count($fileSets) > 0) { ?>
 		
 
-		<? foreach ($fileSets as $fs) { ?>
+		<?php foreach ($fileSets as $fs) { ?>
 		
 			<div class="ccm-group">
 				<a class="ccm-group-inner" href="<?=$view->url('/dashboard/files/sets/', 'view_detail', $fs->getFileSetID())?>"><i class="fa fa-cubes"></i> <?=$fs->getFileSetName()?></a>
 			</div>
 		
-		<? }
+		<?php }
 		
 		
 	} else { ?>
 	
 		<p><?=t('No file sets found.')?></p>
 	
-	<? } ?>
+	<?php } ?>
 
 
-	<? if ($fsl->requiresPaging()) { ?>
-		<? $fsl->displayPagingV2(); ?>
-	<? } ?>
+	<?php if ($fsl->requiresPaging()) { ?>
+		<?php $fsl->displayPagingV2(); ?>
+	<?php } ?>
 
         </section>
 


### PR DESCRIPTION
To fix one of the requests from #1740 (that part was pretty much independent of all the rest) I did the following:

- Refactored the fileset page
- Change list to a table (using the same formatting than the file manager)
- Added more info to the list (file name, title, date)
- Added a little tweak to the sortable
- Added the ability to sort ability on titles

For information, the date is converted to a timestamp (int) for the sorting in order to avoid possible localization issues.

Also, the sort is not saved unless you hit the save button, and you can still move around the files after any sort. This should make working with large filesets a lot easier.

BTW, it now looks like this:

![fileset](https://cloud.githubusercontent.com/assets/3543067/5589358/078b2194-911d-11e4-9b32-03b58ff4cbc8.png)

