### PR TITLE
Fix to bug where saving the design panel clears the page's page type

### DIFF
--- a/web/concrete/controllers/panel/page/design.php
+++ b/web/concrete/controllers/panel/page/design.php
@@ -163,16 +163,12 @@ class Design extends BackendUIPageController {
 
                 if ($cp->canEditPageType()) {
                     $ptID = $c->getPageTypeID();
-                    if ($ptID != $_POST['ptID']) {
-                        // the page type has changed.
-                        if ($_POST['ptID']) {
-                            $type = Type::getByID($_POST['ptID']);
-                            if (is_object($type)) {
-                                $nvc->setPageType($type);
-                            }
-                        } else {
-                            $nvc->setPageType(null);
-                        }
+                    if ($_POST['ptID'] && $ptID != $_POST['ptID']) {
+                        // the page type has changed. 
+                        $type = Type::getByID($_POST['ptID']);
+                        if (is_object($type)) {
+                           $nvc->setPageType($type);
+                        }         
                     }
                 }
 			}


### PR DESCRIPTION
This is to fix a bug where:
- You create a new page
- You save the page, edit, whatever
- Edit the page, open the Design panel and click save from there
- After the save, the page type of the page has been cleared/nulled.

Code wise, this now checks to see if $_POST['ptID'] actually has a value - the design panel isn’t currently posting a ptID value, so it will always return true for: 
if ($ptID != $_POST['ptID']) {

Not sure of the case where'd you'd want to set the page type to null. 