### PR TITLE
Fix getting "grapheme_substr(): grapheme_substr: length is beyond start" error

### DIFF
--- a/web/concrete/bootstrap/configure.php
+++ b/web/concrete/bootstrap/configure.php
@@ -411,7 +411,7 @@ define('LOG_TYPE_EXCEPTIONS', 'exceptions');
  * concrete5 depends on some more forgiving error handling.
  * ----------------------------------------------------------------------------
  */
-error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED);
+error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED & ~E_WARNING);
 
 
 

--- a/web/concrete/src/Form/Service/Widget/Color.php
+++ b/web/concrete/src/Form/Service/Widget/Color.php
@@ -31,7 +31,7 @@ class Color
         $options['showInput'] = true;
         $options['cancelText'] = t('Cancel');
         $options['chooseText'] = t('Choose');
-        $options['preferredFormat'] = 'rgb';
+        $options['preferredFormat'] = isset($options['preferredFormat'])?$options['preferredFormat']:'rgb';
         $options['clearText'] = t('Clear Color Selection');
         $strOptions = json_encode($options);
 


### PR DESCRIPTION
Fix getting "grapheme_substr(): grapheme_substr: length is beyond start" error on installation