### PR TITLE
Remove empty h2-tag, add placeholder alt tag

### DIFF
--- a/web/concrete/blocks/image_slider/view.php
+++ b/web/concrete/blocks/image_slider/view.php
@@ -38,11 +38,17 @@ $(document).ready(function(){
                 ?>
                 <?php if(is_object($f)) {
                     $tag = Core::make('html/image', array($f, false))->getTag();
-                    $tag->alt($row['title']);
+                    if($row['title']) {
+                    	$tag->alt($row['title']);
+                    }else{
+                    	$tag->alt("slide"); 
+                    }
                     print $tag; ?>
                 <?php } ?>
                 <div class="ccm-image-slider-text">
-                    <h2 class="ccm-image-slider-title"><?php echo $row['title'] ?></h2>
+                    <?php if($row['title']) { ?>
+                    	<h2 class="ccm-image-slider-title"><?php echo $row['title'] ?></h2>
+                    <?php } ?>
                     <?php echo $row['description'] ?>
                 </div>
                 </li>


### PR DESCRIPTION
If a user is not placing a title for each slide, the h2 tag of the title is empty. This causes a warning with w3c-validation.
If a user is not placing a title for each slide, there is no alt-tag inside img-tag. This causes validation-error with w3c-validation.

In my fix the h2-tag is not shown, when the title of the image is empty. Same for the alt-tag.