### PR TITLE
Update ItemList.php

### DIFF
--- a/web/concrete/src/Search/ItemList/Database/ItemList.php
+++ b/web/concrete/src/Search/ItemList/Database/ItemList.php
@@ -68,6 +68,7 @@ abstract class ItemList extends AbstractItemList
     protected function executeSortBy($column, $direction = 'asc')
     {
         if (strcasecmp($column, 'rand()') == 0 ||
+            stripos($column, 'FIELD')!==FALSE ||
             preg_match('/[^0-9a-zA-Z\$\.\_\x{0080}-\x{ffff}]+/u', $column) === 0
             && in_array(strtolower($direction), array('asc','desc'))
         ) {


### PR DESCRIPTION
New changes at the *executeSortBy* doed not support sorting base on FIELD (e.g: ORDER BY FIELD(f.fID, '16,15')).
It breaks one of my add-on (Whale Galleria) which use this type of sorting for images priority.
