### PR TITLE
Change the $_REQUEST to $_GET so the cookie data does not overwrite the ...

### DIFF
--- a/web/concrete/tools/dashboard/sitemap_data.php
+++ b/web/concrete/tools/dashboard/sitemap_data.php
@@ -31,7 +31,7 @@ if ($_REQUEST['displayNodePagination']) {
     $dh->setDisplayNodePagination(false);
 }
 
-if ($_REQUEST['includeSystemPages']) {
+if ($_GET['includeSystemPages']) {
     $dh->setIncludeSystemPages(true);
 } else {
     $dh->setIncludeSystemPages(false);


### PR DESCRIPTION
...parameter in ajax call.

http://www.concrete5.org/developers/bugs/5-7-3/unchecking-include-system-pages-in-sitemap-doesnt-work/