### PR TITLE
Add js template asset and template tag attributes

### DIFF
--- a/web/concrete/src/Asset/Asset.php
+++ b/web/concrete/src/Asset/Asset.php
@@ -18,6 +18,19 @@ abstract class Asset
 
     protected $tagAttributes = array();
 
+    const ASSET_POSITION_HEADER = 'H';
+    const ASSET_POSITION_FOOTER = 'F';
+
+    abstract public function getAssetDefaultPosition();
+
+    abstract public function getAssetType();
+
+    abstract public function minify($assets);
+
+    abstract public function combine($assets);
+
+    abstract public function __toString();
+
     public function setTagAttributes(array $attrs)
     {
         $this->tagAttributes = $attrs;
@@ -43,18 +56,6 @@ abstract class Asset
         return $str;
     }
 
-    const ASSET_POSITION_HEADER = 'H';
-    const ASSET_POSITION_FOOTER = 'F';
-
-    abstract public function getAssetDefaultPosition();
-
-    abstract public function getAssetType();
-
-    abstract public function minify($assets);
-
-    abstract public function combine($assets);
-
-    abstract public function __toString();
 
     public function assetSupportsMinification()
     {

--- a/web/concrete/src/Asset/Asset.php
+++ b/web/concrete/src/Asset/Asset.php
@@ -16,6 +16,33 @@ abstract class Asset
     protected $pkg;
     protected $combinedAssetSourceFiles = array();
 
+    protected $tagAttributes = array();
+
+    public function setTagAttributes(array $attrs)
+    {
+        $this->tagAttributes = $attrs;
+    }
+
+    public function getTagAttributes()
+    {
+        return $this->tagAttributes;
+    }
+
+    public function setTagAttribute($key, $val)
+    {
+        $this->tagAttributes[$key] = $val;
+    }
+
+    public function getTagAttributeString()
+    {
+        $str = '';
+        $space = '';
+        foreach ($this->tagAttributes as $key => $val) {
+            $str .= "$space$key=\"$val\"";
+        }
+        return $str;
+    }
+
     const ASSET_POSITION_HEADER = 'H';
     const ASSET_POSITION_FOOTER = 'F';
 

--- a/web/concrete/src/Asset/Asset.php
+++ b/web/concrete/src/Asset/Asset.php
@@ -52,6 +52,7 @@ abstract class Asset
         $space = '';
         foreach ($this->tagAttributes as $key => $val) {
             $str .= "$space$key=\"$val\"";
+            $space = ' ';
         }
         return $str;
     }

--- a/web/concrete/src/Asset/AssetGroup.php
+++ b/web/concrete/src/Asset/AssetGroup.php
@@ -1,47 +1,54 @@
 <?php
-
 namespace Concrete\Core\Asset;
-class AssetGroup {
+
+class AssetGroup
+{
     /** @var \Concrete\Core\Asset\AssetPointer[] */
-	protected $assetPointers = array();
-	protected $assets = array();
+    protected $assetPointers = array();
+    protected $assets = array();
 
-	public function contains(AssetPointer $ap) {
-		foreach($this->assetPointers as $assetPointer) {
-			if ($assetPointer->getHandle() == $ap->getHandle() && $assetPointer->getType() == $ap->getType()) {
-				return true;
-			}
-		}
-		return false;
-	}
+    public function contains(AssetPointer $ap)
+    {
+        foreach($this->assetPointers as $assetPointer) {
+            if ($assetPointer->getHandle() == $ap->getHandle() && $assetPointer->getType() == $ap->getType()) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	public function addGroup(AssetGroup $item) {
-		$assetPointers = $item->getAssetPointers();
-		foreach($assetPointers as $assetPointer) {
-			if (!$this->contains($assetPointer)) {
-				$this->assetPointers[] = $assetPointer;
-			}
-		}
-	}
+    public function addGroup(AssetGroup $item)
+    {
+        $assetPointers = $item->getAssetPointers();
+        foreach($assetPointers as $assetPointer) {
+            if (!$this->contains($assetPointer)) {
+                $this->assetPointers[] = $assetPointer;
+            }
+        }
+    }
 
-	public function addAsset(Asset $asset) {
-		// doesn't check anything. this is useful for layouts, etc... other handle-less assets.
-		$this->assets[] = $asset;
-	}
+    public function addAsset(Asset $asset)
+    {
+        // doesn't check anything. this is useful for layouts, etc... other handle-less assets.
+        $this->assets[] = $asset;
+    }
 
 
-	public function add(AssetPointer $ap) {
-		if (!$this->contains($ap)) {
-			$this->assetPointers[] = $ap;
-		}
-	}
+    public function add(AssetPointer $ap)
+    {
+        if (!$this->contains($ap)) {
+            $this->assetPointers[] = $ap;
+        }
+    }
 
-	public function getAssets() {
-		return $this->assets;
-	}
+    public function getAssets()
+    {
+        return $this->assets;
+    }
 
-	public function getAssetPointers() {
-		return $this->assetPointers;
-	}
+    public function getAssetPointers()
+    {
+        return $this->assetPointers;
+    }
 
 }

--- a/web/concrete/src/Asset/AssetList.php
+++ b/web/concrete/src/Asset/AssetList.php
@@ -57,6 +57,7 @@ class AssetList
         if ($args['position']) {
             $o->setAssetPosition($args['position']);
         }
+        if ($args['attributes']) $o->setTagAttributes($args['attributes']);
         $this->registerAsset($o);
         return $o;
     }

--- a/web/concrete/src/Asset/AssetList.php
+++ b/web/concrete/src/Asset/AssetList.php
@@ -57,7 +57,9 @@ class AssetList
         if ($args['position']) {
             $o->setAssetPosition($args['position']);
         }
-        if ($args['attributes']) $o->setTagAttributes($args['attributes']);
+        if ($args['attributes']) {
+            $o->setTagAttributes($args['attributes']);
+        }
         $this->registerAsset($o);
         return $o;
     }

--- a/web/concrete/src/Asset/AssetList.php
+++ b/web/concrete/src/Asset/AssetList.php
@@ -1,61 +1,65 @@
 <?php
-
 namespace Concrete\Core\Asset;
+
 use Concrete\Core\Foundation\Object as Object;
 use Concrete\Core\Package\Package;
 
-class AssetList {
-	private static $loc = null;
-	public $assets = array();
-	public $assetGroups = array();
+class AssetList
+{
+    private static $loc = null;
+    public $assets = array();
+    public $assetGroups = array();
 
-	public function getRegisteredAssets() {
-		return $this->assets;
-	}
+    public function getRegisteredAssets()
+    {
+        return $this->assets;
+    }
 
-	public static function getInstance() {
-		if (null === self::$loc) {
-			self::$loc = new self;
-		}
-		return self::$loc;
-	}
+    public static function getInstance()
+    {
+        if (null === self::$loc) {
+            self::$loc = new self;
+        }
+        return self::$loc;
+    }
 
-	public function register($assetType, $assetHandle, $filename, $args = array(), $pkg = false) {
-		$defaults = array(
-			'position' => false,
-			'local' => true,
-			'version' => false,
-			'combine' => -1,
-			'minify' => -1 // use the asset default
-		);
-		// overwrite all the defaults with the arguments
-		$args = array_merge($defaults, $args);
+    public function register($assetType, $assetHandle, $filename, $args = array(), $pkg = false)
+    {
+        $defaults = array(
+            'position' => false,
+            'local' => true,
+            'version' => false,
+            'combine' => -1,
+            'minify' => -1 // use the asset default
+        );
+        // overwrite all the defaults with the arguments
+        $args = array_merge($defaults, $args);
 
-		$class = '\\Concrete\\Core\\Asset\\' . Object::camelcase($assetType) . 'Asset';
-		$o = new $class($assetHandle);
+        $class = '\\Concrete\\Core\\Asset\\' . Object::camelcase($assetType) . 'Asset';
+        $o = new $class($assetHandle);
         if ($pkg != false) {
             if (!($pkg instanceof Package)) {
                 $pkg = Package::getByHandle($pkg);
             }
-    		$o->setPackageObject($pkg);
+            $o->setPackageObject($pkg);
         }
-		$o->setAssetIsLocal($args['local']);
-		$o->mapAssetLocation($filename);
-		if ($args['minify'] === true || $args['minify'] === false) {
-			$o->setAssetSupportsMinification($args['minify']);
-		}
-		if ($args['combine'] === true || $args['combine'] === false) {
-			$o->setAssetSupportsCombination($args['combine']);
-		}
-		if ($args['version']) {
-			$o->setAssetVersion($args['version']);
-		}
-		if ($args['position']) {
-			$o->setAssetPosition($args['position']);
-		}
-		$this->registerAsset($o);
-		return $o;
-	}
+        $o->setAssetIsLocal($args['local']);
+        $o->mapAssetLocation($filename);
+        if ($args['minify'] === true || $args['minify'] === false) {
+            $o->setAssetSupportsMinification($args['minify']);
+        }
+        if ($args['combine'] === true || $args['combine'] === false) {
+            $o->setAssetSupportsCombination($args['combine']);
+        }
+        if ($args['version']) {
+            $o->setAssetVersion($args['version']);
+        }
+        if ($args['position']) {
+            $o->setAssetPosition($args['position']);
+        }
+        $this->registerAsset($o);
+        return $o;
+    }
 
     public function registerMultiple(array $assets)
     {
@@ -67,34 +71,36 @@ class AssetList {
         }
     }
 
-	public function registerAsset(Asset $asset) {
-		// we have to check and see if the asset already exists.
-		// If it exists, we only replace it if our current asset has a later version
-		$doRegister = true;
-		if (isset($this->assets[$asset->getAssetType()][$asset->getAssetHandle()])) {
-			$existingAsset = $this->assets[$asset->getAssetType()][$asset->getAssetHandle()];
-			if (version_compare($existingAsset->getAssetVersion(), $asset->getAssetVersion(), '>')) {
-				$doRegister = false;
-			}
-		}
-		if ($doRegister) {
-			$this->assets[$asset->getAssetType()][$asset->getAssetHandle()] = $asset;
-		}
-	}
+    public function registerAsset(Asset $asset)
+    {
+        // we have to check and see if the asset already exists.
+        // If it exists, we only replace it if our current asset has a later version
+        $doRegister = true;
+        if (isset($this->assets[$asset->getAssetType()][$asset->getAssetHandle()])) {
+            $existingAsset = $this->assets[$asset->getAssetType()][$asset->getAssetHandle()];
+            if (version_compare($existingAsset->getAssetVersion(), $asset->getAssetVersion(), '>')) {
+                $doRegister = false;
+            }
+        }
+        if ($doRegister) {
+            $this->assets[$asset->getAssetType()][$asset->getAssetHandle()] = $asset;
+        }
+    }
 
-	public function registerGroup($assetGroupHandle, $assetHandles, $customClass = false) {
-		if ($customClass) {
-			$class = '\\Concrete\\Core\\Asset\\Group\\' . Object::camelcase($assetGroupHandle) . 'AssetGroup';
-		} else {
-			$class = '\\Concrete\\Core\\Asset\\AssetGroup';
-		}
-		$group = new $class();
-		foreach($assetHandles as $assetArray) {
-			$ap = new AssetPointer($assetArray[0], $assetArray[1]);
-			$group->add($ap);
-		}
-		$this->assetGroups[$assetGroupHandle] = $group;
-	}
+    public function registerGroup($assetGroupHandle, $assetHandles, $customClass = false)
+    {
+        if ($customClass) {
+            $class = '\\Concrete\\Core\\Asset\\Group\\' . Object::camelcase($assetGroupHandle) . 'AssetGroup';
+        } else {
+            $class = '\\Concrete\\Core\\Asset\\AssetGroup';
+        }
+        $group = new $class();
+        foreach($assetHandles as $assetArray) {
+            $ap = new AssetPointer($assetArray[0], $assetArray[1]);
+            $group->add($ap);
+        }
+        $this->assetGroups[$assetGroupHandle] = $group;
+    }
 
     public function registerGroupMultiple(array $asset_groups)
     {
@@ -104,16 +110,18 @@ class AssetList {
         }
     }
 
-	public function getAsset($assetType, $assetHandle) {
-		return $this->assets[$assetType][$assetHandle];
-	}
+    public function getAsset($assetType, $assetHandle)
+    {
+        return $this->assets[$assetType][$assetHandle];
+    }
 
     /**
      * @param string $assetGroupHandle
      * @return \Concrete\Core\Asset\AssetGroup
      */
-    public function getAssetGroup($assetGroupHandle) {
-		return $this->assetGroups[$assetGroupHandle];
-	}
+    public function getAssetGroup($assetGroupHandle)
+    {
+        return $this->assetGroups[$assetGroupHandle];
+    }
 
 }

--- a/web/concrete/src/Asset/AssetPointer.php
+++ b/web/concrete/src/Asset/AssetPointer.php
@@ -1,21 +1,32 @@
 <?php
 namespace Concrete\Core\Asset;
-class AssetPointer {
 
-	protected $assetType;
-	protected $assetHandle;
+class AssetPointer
+{
 
-	public function getType() {return $this->assetType;}
-	public function getHandle() {return $this->assetHandle;}
+    protected $assetType;
+    protected $assetHandle;
 
-	public function __construct($assetType, $assetHandle) {
-		$this->assetType = $assetType;
-		$this->assetHandle = $assetHandle;
-	}
+    public function getType()
+    {
+        return $this->assetType;
+    }
 
-	public function getAsset() {
-		$al = AssetList::getInstance();
-		return $al->getAsset($this->assetType, $this->assetHandle);
-	}
+    public function getHandle()
+    {
+        return $this->assetHandle;
+    }
+
+    public function __construct($assetType, $assetHandle)
+    {
+        $this->assetType = $assetType;
+        $this->assetHandle = $assetHandle;
+    }
+
+    public function getAsset()
+    {
+        $al = AssetList::getInstance();
+        return $al->getAsset($this->assetType, $this->assetHandle);
+    }
 
 }

--- a/web/concrete/src/Asset/CssAsset.php
+++ b/web/concrete/src/Asset/CssAsset.php
@@ -5,33 +5,40 @@ use HtmlObject\Element;
 use Concrete\Core\Html\Object\HeadLink;
 use Config;
 
-class CssAsset extends Asset {
+class CssAsset extends Asset
+{
 
-	protected $assetSupportsMinification = true;
-	protected $assetSupportsCombination = true;
+    protected $assetSupportsMinification = true;
+    protected $assetSupportsCombination = true;
 
-	public function getAssetDefaultPosition() {
-		return Asset::ASSET_POSITION_HEADER;
-	}
+    public function getAssetDefaultPosition()
+    {
+        return Asset::ASSET_POSITION_HEADER;
+    }
 
-	public function getAssetType() {return 'css';}
+    public function getAssetType()
+    {
+        return 'css';
+    }
 
-	protected static function getRelativeOutputDirectory() {
-		return REL_DIR_FILES_CACHE . '/' . DIRNAME_CSS;
-	}
+    protected static function getRelativeOutputDirectory()
+    {
+        return REL_DIR_FILES_CACHE . '/' . DIRNAME_CSS;
+    }
 
-	protected static function getOutputDirectory() {
-		if (!file_exists(Config::get('concrete.cache.directory') . '/' . DIRNAME_CSS)) {
-			$proceed = @mkdir(Config::get('concrete.cache.directory') . '/' . DIRNAME_CSS);
-		} else {
-			$proceed = true;
-		}
-		if ($proceed) {
-			return Config::get('concrete.cache.directory') . '/' . DIRNAME_CSS;
-		} else {
-			return false;
-		}
-	}
+    protected static function getOutputDirectory()
+    {
+        if (!file_exists(Config::get('concrete.cache.directory') . '/' . DIRNAME_CSS)) {
+            $proceed = @mkdir(Config::get('concrete.cache.directory') . '/' . DIRNAME_CSS);
+        } else {
+            $proceed = true;
+        }
+        if ($proceed) {
+            return Config::get('concrete.cache.directory') . '/' . DIRNAME_CSS;
+        } else {
+            return false;
+        }
+    }
 
     static function changePaths( $content, $current_path, $target_path )
     {
@@ -90,50 +97,54 @@ class CssAsset extends Asset {
         return $content;
     }
 
-    protected static function process($assets, $processFunction) {
-		if ($directory = self::getOutputDirectory()) {
+    protected static function process($assets, $processFunction)
+    {
+        if ($directory = self::getOutputDirectory()) {
 
-			$filename = '';
-			for ($i = 0; $i < count($assets); $i++) {
-				$asset = $assets[$i];
-				$filename .= $asset->getAssetURL();
+            $filename = '';
+            for ($i = 0; $i < count($assets); $i++) {
+                $asset = $assets[$i];
+                $filename .= $asset->getAssetURL();
                 $sourceFiles[] = $asset->getAssetURL();
-			}
-			$filename = sha1($filename);
-			$cacheFile = $directory . '/' . $filename . '.css';
-			if (!file_exists($cacheFile)) {
-				$css = '';
-				foreach($assets as $asset) {
+            }
+            $filename = sha1($filename);
+            $cacheFile = $directory . '/' . $filename . '.css';
+            if (!file_exists($cacheFile)) {
+                $css = '';
+                foreach($assets as $asset) {
                     if ($asset->getAssetPath()) {
                         $css .= file_get_contents($asset->getAssetPath()) . "\n\n";
                     }
-					$css = $processFunction($css, $asset->getAssetURLPath(), self::getRelativeOutputDirectory());
-				}
-				@file_put_contents($cacheFile, $css);
-			}
+                    $css = $processFunction($css, $asset->getAssetURLPath(), self::getRelativeOutputDirectory());
+                }
+                @file_put_contents($cacheFile, $css);
+            }
 
-			$asset = new CSSAsset();
-			$asset->setAssetURL(self::getRelativeOutputDirectory() . '/' . $filename . '.css');
-			$asset->setAssetPath($directory . '/' . $filename . '.css');
+            $asset = new CSSAsset();
+            $asset->setAssetURL(self::getRelativeOutputDirectory() . '/' . $filename . '.css');
+            $asset->setAssetPath($directory . '/' . $filename . '.css');
             $asset->setCombinedAssetSourceFiles($sourceFiles);
-			return array($asset);
-		}
-		return $assets;
+            return array($asset);
+        }
+        return $assets;
     }
 
-	public function combine($assets) {
-		return self::process($assets, function($css, $assetPath, $targetPath) {
-			return CSSAsset::changePaths($css, $assetPath, $targetPath);
-		});
-	}
+    public function combine($assets)
+    {
+        return self::process($assets, function($css, $assetPath, $targetPath) {
+            return CSSAsset::changePaths($css, $assetPath, $targetPath);
+        });
+    }
 
-	public function minify($assets) {
-		return self::process($assets, function($css, $assetPath, $targetPath) {
-			return \CssMin::minify(CSSAsset::changePaths($css, $assetPath, $targetPath));
-		});
-	}
+    public function minify($assets)
+    {
+        return self::process($assets, function($css, $assetPath, $targetPath) {
+            return \CssMin::minify(CSSAsset::changePaths($css, $assetPath, $targetPath));
+        });
+    }
 
-	public function __toString() {
+    public function __toString()
+    {
         $e = new HeadLink($this->getAssetURL(), 'stylesheet', 'text/css', 'all');
         if (count($this->combinedAssetSourceFiles)) {
             $source = '';
@@ -145,7 +156,5 @@ class CssAsset extends Asset {
         }
         return (string) $e;
     }
-
-
 
 }

--- a/web/concrete/src/Asset/CssAsset.php
+++ b/web/concrete/src/Asset/CssAsset.php
@@ -146,6 +146,7 @@ class CssAsset extends Asset
     public function __toString()
     {
         $e = new HeadLink($this->getAssetURL(), 'stylesheet', 'text/css', 'all');
+        $e->setAttributes($this->getTagAttributes());
         if (count($this->combinedAssetSourceFiles)) {
             $source = '';
             foreach($this->combinedAssetSourceFiles as $file) {

--- a/web/concrete/src/Asset/JavascriptAsset.php
+++ b/web/concrete/src/Asset/JavascriptAsset.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\Asset;
 use HtmlObject\Element;
 use Config;
 
-class JavascriptAsset extends Asset 
+class JavascriptAsset extends Asset
 {
 
     protected $assetSupportsMinification = true;
@@ -12,17 +12,17 @@ class JavascriptAsset extends Asset
 
     protected $scriptType = 'text/javascript';
 
-    public function getAssetDefaultPosition() 
+    public function getAssetDefaultPosition()
     {
         return Asset::ASSET_POSITION_FOOTER;
     }
 
-    public function getRelativeOutputDirectory() 
+    public function getRelativeOutputDirectory()
     {
         return REL_DIR_FILES_CACHE . '/' . DIRNAME_JAVASCRIPT;
     }
 
-    protected static function getOutputDirectory() 
+    protected static function getOutputDirectory()
     {
         if (!file_exists(Config::get('concrete.cache.directory') . '/' . DIRNAME_JAVASCRIPT)) {
             $proceed = @mkdir(Config::get('concrete.cache.directory') . '/' . DIRNAME_JAVASCRIPT);
@@ -36,7 +36,7 @@ class JavascriptAsset extends Asset
         }
     }
 
-    protected static function process($assets, $processFunction) 
+    protected static function process($assets, $processFunction)
     {
         if ($directory = self::getOutputDirectory()) {
             $filename = '';
@@ -66,26 +66,26 @@ class JavascriptAsset extends Asset
         return $assets;
     }
 
-    public function combine($assets) 
+    public function combine($assets)
     {
         return self::process($assets, function($js, $assetPath, $targetPath) {
             return $js;
         });
     }
 
-    public function minify($assets) 
+    public function minify($assets)
     {
         return self::process($assets, function($js, $assetPath, $targetPath) {
             return \JShrink\Minifier::minify($js);
         });
     }
 
-    public function getAssetType() 
+    public function getAssetType()
     {
         return 'javascript';
     }
 
-    public function __toString() 
+    public function __toString()
     {
         $e = new Element('script');
         $e->setAttributes($this->getTagAttributes());

--- a/web/concrete/src/Asset/JavascriptAsset.php
+++ b/web/concrete/src/Asset/JavascriptAsset.php
@@ -1,22 +1,27 @@
 <?php
 namespace Concrete\Core\Asset;
+
 use HtmlObject\Element;
 use Config;
 
-class JavascriptAsset extends Asset {
+class JavascriptAsset extends Asset 
+{
 
 	protected $assetSupportsMinification = true;
 	protected $assetSupportsCombination = true;
 
-	public function getAssetDefaultPosition() {
+    public function getAssetDefaultPosition() 
+    {
 		return Asset::ASSET_POSITION_FOOTER;
 	}
 
-	public function getRelativeOutputDirectory() {
+    public function getRelativeOutputDirectory() 
+    {
 		return REL_DIR_FILES_CACHE . '/' . DIRNAME_JAVASCRIPT;
 	}
 
-	protected static function getOutputDirectory() {
+    protected static function getOutputDirectory() 
+    {
 		if (!file_exists(Config::get('concrete.cache.directory') . '/' . DIRNAME_JAVASCRIPT)) {
 			$proceed = @mkdir(Config::get('concrete.cache.directory') . '/' . DIRNAME_JAVASCRIPT);
 		} else {
@@ -29,7 +34,8 @@ class JavascriptAsset extends Asset {
 		}
 	}
 
-    protected static function process($assets, $processFunction) {
+    protected static function process($assets, $processFunction) 
+    {
 		if ($directory = self::getOutputDirectory()) {
 			$filename = '';
             $sourceFiles = array();
@@ -58,21 +64,27 @@ class JavascriptAsset extends Asset {
 		return $assets;
     }
 
-	public function combine($assets) {
+    public function combine($assets) 
+    {
 		return self::process($assets, function($js, $assetPath, $targetPath) {
 			return $js;
 		});
 	}
 
-	public function minify($assets) {
+    public function minify($assets) 
+    {
 		return self::process($assets, function($js, $assetPath, $targetPath) {
 			return \JShrink\Minifier::minify($js);
 		});
 	}
 
-	public function getAssetType() {return 'javascript';}
+    public function getAssetType() 
+    {
+        return 'javascript';
+    }
 
-	public function __toString() {
+    public function __toString() 
+    {
         $e = new Element('script');
         $e->type('text/javascript')->src($this->getAssetURL());
         if (count($this->combinedAssetSourceFiles)) {

--- a/web/concrete/src/Asset/JavascriptAsset.php
+++ b/web/concrete/src/Asset/JavascriptAsset.php
@@ -7,76 +7,76 @@ use Config;
 class JavascriptAsset extends Asset 
 {
 
-	protected $assetSupportsMinification = true;
-	protected $assetSupportsCombination = true;
+    protected $assetSupportsMinification = true;
+    protected $assetSupportsCombination = true;
 
     public function getAssetDefaultPosition() 
     {
-		return Asset::ASSET_POSITION_FOOTER;
-	}
+        return Asset::ASSET_POSITION_FOOTER;
+    }
 
     public function getRelativeOutputDirectory() 
     {
-		return REL_DIR_FILES_CACHE . '/' . DIRNAME_JAVASCRIPT;
-	}
+        return REL_DIR_FILES_CACHE . '/' . DIRNAME_JAVASCRIPT;
+    }
 
     protected static function getOutputDirectory() 
     {
-		if (!file_exists(Config::get('concrete.cache.directory') . '/' . DIRNAME_JAVASCRIPT)) {
-			$proceed = @mkdir(Config::get('concrete.cache.directory') . '/' . DIRNAME_JAVASCRIPT);
-		} else {
-			$proceed = true;
-		}
-		if ($proceed) {
-			return Config::get('concrete.cache.directory') . '/' . DIRNAME_JAVASCRIPT;
-		} else {
-			return false;
-		}
-	}
+        if (!file_exists(Config::get('concrete.cache.directory') . '/' . DIRNAME_JAVASCRIPT)) {
+            $proceed = @mkdir(Config::get('concrete.cache.directory') . '/' . DIRNAME_JAVASCRIPT);
+        } else {
+            $proceed = true;
+        }
+        if ($proceed) {
+            return Config::get('concrete.cache.directory') . '/' . DIRNAME_JAVASCRIPT;
+        } else {
+            return false;
+        }
+    }
 
     protected static function process($assets, $processFunction) 
     {
-		if ($directory = self::getOutputDirectory()) {
-			$filename = '';
+        if ($directory = self::getOutputDirectory()) {
+            $filename = '';
             $sourceFiles = array();
-			for ($i = 0; $i < count($assets); $i++) {
-				$asset = $assets[$i];
-				$filename .= $asset->getAssetURL();
+            for ($i = 0; $i < count($assets); $i++) {
+                $asset = $assets[$i];
+                $filename .= $asset->getAssetURL();
                 $sourceFiles[] = $asset->getAssetURL();
-			}
-			$filename = sha1($filename);
-			$cacheFile = $directory . '/' . $filename . '.js';
-			if (!file_exists($cacheFile)) {
-				$js = '';
-				foreach($assets as $asset) {
-					$js .= file_get_contents($asset->getAssetPath()) . "\n\n";
-					$js = $processFunction($js, $asset->getAssetURLPath(), self::getRelativeOutputDirectory());
-				}
-				@file_put_contents($cacheFile, $js);
-			}
+            }
+            $filename = sha1($filename);
+            $cacheFile = $directory . '/' . $filename . '.js';
+            if (!file_exists($cacheFile)) {
+                $js = '';
+                foreach($assets as $asset) {
+                    $js .= file_get_contents($asset->getAssetPath()) . "\n\n";
+                    $js = $processFunction($js, $asset->getAssetURLPath(), self::getRelativeOutputDirectory());
+                }
+                @file_put_contents($cacheFile, $js);
+            }
 
-			$asset = new JavascriptAsset();
-			$asset->setAssetURL(self::getRelativeOutputDirectory() . '/' . $filename . '.js');
-			$asset->setAssetPath($directory . '/' . $filename . '.js');
+            $asset = new JavascriptAsset();
+            $asset->setAssetURL(self::getRelativeOutputDirectory() . '/' . $filename . '.js');
+            $asset->setAssetPath($directory . '/' . $filename . '.js');
             $asset->setCombinedAssetSourceFiles($sourceFiles);
-			return array($asset);
-		}
-		return $assets;
+            return array($asset);
+        }
+        return $assets;
     }
 
     public function combine($assets) 
     {
-		return self::process($assets, function($js, $assetPath, $targetPath) {
-			return $js;
-		});
-	}
+        return self::process($assets, function($js, $assetPath, $targetPath) {
+            return $js;
+        });
+    }
 
     public function minify($assets) 
     {
-		return self::process($assets, function($js, $assetPath, $targetPath) {
-			return \JShrink\Minifier::minify($js);
-		});
-	}
+        return self::process($assets, function($js, $assetPath, $targetPath) {
+            return \JShrink\Minifier::minify($js);
+        });
+    }
 
     public function getAssetType() 
     {
@@ -96,6 +96,6 @@ class JavascriptAsset extends Asset
             $e->setAttribute('data-source', $source);
         }
         return (string) $e;
-	}
+    }
 
 }

--- a/web/concrete/src/Asset/JavascriptAsset.php
+++ b/web/concrete/src/Asset/JavascriptAsset.php
@@ -10,6 +10,8 @@ class JavascriptAsset extends Asset
     protected $assetSupportsMinification = true;
     protected $assetSupportsCombination = true;
 
+    protected $scriptType = 'text/javascript';
+
     public function getAssetDefaultPosition() 
     {
         return Asset::ASSET_POSITION_FOOTER;
@@ -86,7 +88,8 @@ class JavascriptAsset extends Asset
     public function __toString() 
     {
         $e = new Element('script');
-        $e->type('text/javascript')->src($this->getAssetURL());
+        $e->setAttributes($this->getTagAttributes());
+        $e->type($this->scriptType)->src($this->getAssetURL());
         if (count($this->combinedAssetSourceFiles)) {
             $source = '';
             foreach($this->combinedAssetSourceFiles as $file) {

--- a/web/concrete/src/Asset/JavascriptInlineAsset.php
+++ b/web/concrete/src/Asset/JavascriptInlineAsset.php
@@ -24,7 +24,8 @@ class JavascriptInlineAsset extends JavascriptAsset
 
     public function __toString()
     {
-        return '<script type="text/javascript">' . $this->getAssetURL() . '</script>';
+        $attrs = $this->getTagAttributeString();
+        return '<script '. $attrs .' type="'. $this->scriptType . '">' . $this->getAssetURL() . '</script>';
     }
 
 }

--- a/web/concrete/src/Asset/JsTemplateAsset.php
+++ b/web/concrete/src/Asset/JsTemplateAsset.php
@@ -1,0 +1,22 @@
+<?php
+namespace Concrete\Core\Asset;
+
+class JsTemplateAsset extends JavascriptAsset
+{
+    protected $assetSupportsMinification = false;
+    protected $assetSupportsCombination = false;
+
+    protected $scriptType = 'text/template';
+
+    public function getAssetType()
+    {
+        return 'js-template';
+    }
+
+    public function getAssetDefaultPosition()
+    {
+        return Asset::ASSET_POSITION_HEADER;
+    }
+
+
+}


### PR DESCRIPTION
This pull request adds a new "js-template" asset type as well as the ability to add attributes to asset tags.

Along the way I applied PSR-2 refactor to asset classes (mostly braces and spaces)

This is in line with #1773 

If you accept this pull request, I will make use of it in #1762 to fix the file context menu.