### PR TITLE
Add compression level to Image helper

### DIFF
--- a/web/concrete/src/Legacy/ImageHelper.php
+++ b/web/concrete/src/Legacy/ImageHelper.php
@@ -58,16 +58,16 @@ class ImageHelper
             $image = Image::open($mixed);
         }
         if ($fit) {
-            return $image->thumbnail(new Box($width, $height), ImageInterface::THUMBNAIL_OUTBOUND)->save($newPath);
+            return $image->thumbnail(new Box($width, $height), ImageInterface::THUMBNAIL_OUTBOUND)->save($newPath, array('quality'=>$this->jpegCompression));
 
         } else {
 
             if ($height < 1) {
-                $image->thumbnail($image->getSize()->widen($width))->save($newPath);
+                $image->thumbnail($image->getSize()->widen($width))->save($newPath, array('quality'=>$this->jpegCompression));
             } else if ($width < 1) {
-                $image->thumbnail($image->getSize()->heighten($height))->save($newPath);
+                $image->thumbnail($image->getSize()->heighten($height))->save($newPath, array('quality'=>$this->jpegCompression));
             } else {
-                $image->thumbnail(new Box($width, $height))->save($newPath);
+                $image->thumbnail(new Box($width, $height))->save($newPath, array('quality'=>$this->jpegCompression));
             }
         }
      }


### PR DESCRIPTION
The legacy Image helper has everything needed to set a default compression level, but it doesn't use it at all. Setting the compression level will have absolutely no effect when an image is saved.
This small change fixes that.