### PR TITLE
Fix to get localized Page Type Composer Control Name

### DIFF
--- a/web/concrete/src/Page/Type/Composer/Control/Control.php
+++ b/web/concrete/src/Page/Type/Composer/Control/Control.php
@@ -77,7 +77,7 @@ abstract class Control extends Object
     }
     public function getPageTypeComposerControlDisplayName($format = 'html')
     {
-        $value = tc('PageTypeComposerControlName', $this->getPageTypeComposerControlName());
+        $value = $this->getPageTypeComposerControlName();
         switch ($format) {
             case 'html':
                 return h($value);

--- a/web/concrete/src/Page/Type/Composer/Control/Type/BlockType.php
+++ b/web/concrete/src/Page/Type/Composer/Control/Type/BlockType.php
@@ -23,7 +23,7 @@ class BlockType extends Type {
 				$bx = new BlockControl();
 				$bx->setBlockTypeID($bt->getBlockTypeID());
 				$bx->setPageTypeComposerControlIconSRC($ci->getBlockTypeIconURL($bt));
-				$bx->setPageTypeComposerControlName($bt->getBlockTypeName());
+				$bx->setPageTypeComposerControlName(t($bt->getBlockTypeName()));
 				$objects[] = $bx;
 			}
 		}
@@ -36,7 +36,7 @@ class BlockType extends Type {
 		$bx = new BlockControl();
 		$bx->setBlockTypeID($bt->getBlockTypeID());
 		$bx->setPageTypeComposerControlIconSRC($ci->getBlockTypeIconURL($bt));
-		$bx->setPageTypeComposerControlName($bt->getBlockTypeName());
+		$bx->setPageTypeComposerControlName(t($bt->getBlockTypeName()));
 		return $bx;
 	}
 


### PR DESCRIPTION
* The name of Block Types are not localized
* The name of Core Page Properties and Collection Attribute Types are localized twice