### PR TITLE
Scroll to bottom of page when adding an attribute

### DIFF
--- a/web/concrete/views/panels/details/page/attributes.php
+++ b/web/concrete/views/panels/details/page/attributes.php
@@ -120,6 +120,7 @@ ConcretePageAttributesDetail = {
 			},
 			complete: function() {
 				jQuery.fn.dialog.hideLoader();
+				$('#ccm-panel-detail-page-attributes').scrollTop(100000000);
 			}
 		});
 	}


### PR DESCRIPTION
When the page attributes panel is open and an attribute is added to the
active list, there is no visual feedback that something has been added.
The newly added attribute is added to the bottom of the page, but this
is normally beyond the viewport, requiring a scroll to see it.

This line automatically scrolls the viewport to the bottom, showing the
newly added attribute.