### PR TITLE
Add hover style to add block header accordion

### DIFF
--- a/web/concrete/css/build/core/app/panels/add-block.less
+++ b/web/concrete/css/build/core/app/panels/add-block.less
@@ -31,6 +31,10 @@ div#ccm-panel-add-block {
 			span {
 				color: #60686f;
 				background-color: #202226;
+				&:hover {
+					color: #869f9a;
+					background-color: #111215;
+				}				
 			}
 		}
 	}


### PR DESCRIPTION
This dropdown menu is hard to recognize as the clickable area.

![add_block](https://cloud.githubusercontent.com/assets/514294/5733882/c6dd481c-9bed-11e4-95c2-dc412798e127.png)
