### PR TITLE
Fix inline CSS when having several custom classes

### DIFF
--- a/web/concrete/src/Area/CustomStyle.php
+++ b/web/concrete/src/Area/CustomStyle.php
@@ -19,7 +19,7 @@ class CustomStyle extends AbstractCustomStyle
     public function getCSS()
     {
         $set = $this->set;
-        $css = '.' . $this->getContainerClass('.') . '{';
+        $css = '.' . str_replace(' ', '.', $this->getContainerClass()) . '{';
         if ($set->getBackgroundColor()) {
             $css .= 'background-color:' . $set->getBackgroundColor() . ';';
         }
@@ -87,13 +87,13 @@ class CustomStyle extends AbstractCustomStyle
         return $css;
     }
 
-    public function getContainerClass($separator = ' ')
+    public function getContainerClass()
     {
         $class = 'ccm-custom-style-';
         $txt = Core::make('helper/text');
         $class .= strtolower($txt->filterNonAlphaNum($this->arHandle));
         if (is_object($this->set) && $this->set->getCustomClass()) {
-            $class .= $separator . $this->set->getCustomClass();
+            $class .= ' ' . $this->set->getCustomClass();
         }
         return $class;
     }


### PR DESCRIPTION
When using more than one custom classes in an area, the inline CSS was like this: ".ccm-custom-style-area.first-class second-class"
(Only the first space was replaced with a dot)
I've fixed this by using the same code as in /src/Block/CustomStyle.php

Thanks,

Jordi