### PR TITLE
Add Font Awesome as required asset

### DIFF
--- a/web/concrete/blocks/social_links/controller.php
+++ b/web/concrete/blocks/social_links/controller.php
@@ -134,6 +134,11 @@ class Controller extends BlockController
         $this->set('links', $links);
     }
 
+    public function registerViewAssets()
+    {
+        $this->requireAsset('css', 'font-awesome');
+    }
+
 
 }
 


### PR DESCRIPTION
When a theme without Font Awesome as a required asset was used, the social link icons were not displayed correctly.