### PR TITLE
Feature/integrate translation library

### DIFF
--- a/web/concrete/composer.json
+++ b/web/concrete/composer.json
@@ -22,7 +22,7 @@
         "doctrine/orm": "2.4.*",
         "doctrine/migrations": "1.0.*@dev",
         "concrete5/flysystem": "0.4.*",
-        "gettext/gettext": "2.1",
+        "mlocati/concrete5-translation-library": "dev-master",
         "symfony/event-dispatcher": "2.5.*",
         "symfony/serializer": "2.5.*",
         "illuminate/container": "4.1.*",

--- a/web/concrete/composer.json
+++ b/web/concrete/composer.json
@@ -57,6 +57,6 @@
         "tedivm/stash": "0.12.1",
         "lusitanian/oauth": "~0.3",
         "oryzone/oauth-user-data": "~1.0@dev",
-        "mlocati/concrete5-translation-library": "dev-master"
+        "mlocati/concrete5-translation-library": "1.*"
     }
 }

--- a/web/concrete/composer.json
+++ b/web/concrete/composer.json
@@ -22,7 +22,6 @@
         "doctrine/orm": "2.4.*",
         "doctrine/migrations": "1.0.*@dev",
         "concrete5/flysystem": "0.4.*",
-        "mlocati/concrete5-translation-library": "dev-master",
         "symfony/event-dispatcher": "2.5.*",
         "symfony/serializer": "2.5.*",
         "illuminate/container": "4.1.*",
@@ -57,6 +56,7 @@
         "punic/punic": "1.2.*",
         "tedivm/stash": "0.12.1",
         "lusitanian/oauth": "~0.3",
-        "oryzone/oauth-user-data": "~1.0@dev"
+        "oryzone/oauth-user-data": "~1.0@dev",
+        "mlocati/concrete5-translation-library": "dev-master"
     }
 }

--- a/web/concrete/composer.lock
+++ b/web/concrete/composer.lock
@@ -1479,12 +1479,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlocati/concrete5-translation-library.git",
-                "reference": "cc4f93a468d97ebc9e820edf02f0136ccc16563c"
+                "reference": "c5673cdc7de5a3da6579e76296bd644022ac01cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/cc4f93a468d97ebc9e820edf02f0136ccc16563c",
-                "reference": "cc4f93a468d97ebc9e820edf02f0136ccc16563c",
+                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/c5673cdc7de5a3da6579e76296bd644022ac01cd",
+                "reference": "c5673cdc7de5a3da6579e76296bd644022ac01cd",
                 "shasum": ""
             },
             "require": {
@@ -1521,7 +1521,7 @@
                 "translate",
                 "translation"
             ],
-            "time": "2015-01-23 09:12:28"
+            "time": "2015-01-23 11:38:58"
         },
         {
             "name": "mobiledetect/mobiledetectlib",

--- a/web/concrete/composer.lock
+++ b/web/concrete/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ba6fd3e019fd092e0c6a9038dec90cde",
+    "hash": "4c0d7e32464daafa9caf7d06353b0606",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -909,16 +909,16 @@
         },
         {
             "name": "gettext/gettext",
-            "version": "v2.3.0",
+            "version": "v3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oscarotero/Gettext.git",
-                "reference": "6baa57defc4dfe0fc63220fc3737ef9295af7428"
+                "reference": "e54627b820b9ff838934134ce403e22a7e86dd02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oscarotero/Gettext/zipball/6baa57defc4dfe0fc63220fc3737ef9295af7428",
-                "reference": "6baa57defc4dfe0fc63220fc3737ef9295af7428",
+                "url": "https://api.github.com/repos/oscarotero/Gettext/zipball/e54627b820b9ff838934134ce403e22a7e86dd02",
+                "reference": "e54627b820b9ff838934134ce403e22a7e86dd02",
                 "shasum": ""
             },
             "require": {
@@ -955,7 +955,7 @@
                 "po",
                 "translation"
             ],
-            "time": "2015-01-19 17:58:26"
+            "time": "2015-01-22 21:42:54"
         },
         {
             "name": "hautelook/phpass",
@@ -1479,16 +1479,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlocati/concrete5-translation-library.git",
-                "reference": "23d0cf5213414f2e2126ac27544b5b1a88215238"
+                "reference": "cc4f93a468d97ebc9e820edf02f0136ccc16563c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/23d0cf5213414f2e2126ac27544b5b1a88215238",
-                "reference": "23d0cf5213414f2e2126ac27544b5b1a88215238",
+                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/cc4f93a468d97ebc9e820edf02f0136ccc16563c",
+                "reference": "cc4f93a468d97ebc9e820edf02f0136ccc16563c",
                 "shasum": ""
             },
             "require": {
-                "gettext/gettext": "2.3.*",
+                "gettext/gettext": "3.*",
                 "php": ">=5.3.0"
             },
             "type": "library",
@@ -1521,7 +1521,7 @@
                 "translate",
                 "translation"
             ],
-            "time": "2015-01-20 13:56:52"
+            "time": "2015-01-23 09:12:28"
         },
         {
             "name": "mobiledetect/mobiledetectlib",
@@ -3507,7 +3507,6 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "doctrine/migrations": 20,
-        "mlocati/concrete5-translation-library": 20,
         "patchwork/utf8": 20,
         "imagine/imagine": 20,
         "innogames/cssmin": 20,
@@ -3517,7 +3516,8 @@
         "kertz/twitteroauth": 20,
         "primal/color": 20,
         "zendframework/zend-queue": 20,
-        "oryzone/oauth-user-data": 20
+        "oryzone/oauth-user-data": 20,
+        "mlocati/concrete5-translation-library": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/web/concrete/composer.lock
+++ b/web/concrete/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c45527ab746e75c46b94b9298d0e00c5",
+    "hash": "ba6fd3e019fd092e0c6a9038dec90cde",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -909,16 +909,16 @@
         },
         {
             "name": "gettext/gettext",
-            "version": "v2.1",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oscarotero/Gettext.git",
-                "reference": "2be5da2f975df690910f99ebc7199a28da8b0a1b"
+                "reference": "6baa57defc4dfe0fc63220fc3737ef9295af7428"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oscarotero/Gettext/zipball/2be5da2f975df690910f99ebc7199a28da8b0a1b",
-                "reference": "2be5da2f975df690910f99ebc7199a28da8b0a1b",
+                "url": "https://api.github.com/repos/oscarotero/Gettext/zipball/6baa57defc4dfe0fc63220fc3737ef9295af7428",
+                "reference": "6baa57defc4dfe0fc63220fc3737ef9295af7428",
                 "shasum": ""
             },
             "require": {
@@ -931,10 +931,7 @@
             "autoload": {
                 "psr-4": {
                     "Gettext\\": "src"
-                },
-                "files": [
-                    "src/translator_functions.php"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -958,7 +955,7 @@
                 "po",
                 "translation"
             ],
-            "time": "2014-11-21 13:06:04"
+            "time": "2015-01-19 17:58:26"
         },
         {
             "name": "hautelook/phpass",
@@ -1475,6 +1472,56 @@
                 "markdown"
             ],
             "time": "2014-08-10 19:25:52"
+        },
+        {
+            "name": "mlocati/concrete5-translation-library",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mlocati/concrete5-translation-library.git",
+                "reference": "23d0cf5213414f2e2126ac27544b5b1a88215238"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/23d0cf5213414f2e2126ac27544b5b1a88215238",
+                "reference": "23d0cf5213414f2e2126ac27544b5b1a88215238",
+                "shasum": ""
+            },
+            "require": {
+                "gettext/gettext": "2.3.*",
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "C5TL\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michele Locati",
+                    "email": "mlocati@gmail.com",
+                    "homepage": "https://github.com/mlocati",
+                    "role": "developer"
+                }
+            ],
+            "description": "Library to handle concrete5 core and package translations",
+            "homepage": "https://github.com/mlocati/concrete5-translation-library",
+            "keywords": [
+                "concrete5",
+                "i18n",
+                "internationalization",
+                "l10n",
+                "localization",
+                "packages",
+                "translate",
+                "translation"
+            ],
+            "time": "2015-01-20 13:56:52"
         },
         {
             "name": "mobiledetect/mobiledetectlib",
@@ -3460,6 +3507,7 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "doctrine/migrations": 20,
+        "mlocati/concrete5-translation-library": 20,
         "patchwork/utf8": 20,
         "imagine/imagine": 20,
         "innogames/cssmin": 20,

--- a/web/concrete/composer.lock
+++ b/web/concrete/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4c0d7e32464daafa9caf7d06353b0606",
+    "hash": "eb916751d0bbe065bfd21e78b784533f",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -1475,16 +1475,16 @@
         },
         {
             "name": "mlocati/concrete5-translation-library",
-            "version": "dev-master",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlocati/concrete5-translation-library.git",
-                "reference": "c5673cdc7de5a3da6579e76296bd644022ac01cd"
+                "reference": "58894ed37bf6c76d632b446d18427b2242ec3f8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/c5673cdc7de5a3da6579e76296bd644022ac01cd",
-                "reference": "c5673cdc7de5a3da6579e76296bd644022ac01cd",
+                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/58894ed37bf6c76d632b446d18427b2242ec3f8b",
+                "reference": "58894ed37bf6c76d632b446d18427b2242ec3f8b",
                 "shasum": ""
             },
             "require": {
@@ -1521,7 +1521,7 @@
                 "translate",
                 "translation"
             ],
-            "time": "2015-01-23 11:38:58"
+            "time": "2015-01-23 16:49:37"
         },
         {
             "name": "mobiledetect/mobiledetectlib",
@@ -3516,8 +3516,7 @@
         "kertz/twitteroauth": 20,
         "primal/color": 20,
         "zendframework/zend-queue": 20,
-        "oryzone/oauth-user-data": 20,
-        "mlocati/concrete5-translation-library": 20
+        "oryzone/oauth-user-data": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -211,6 +211,14 @@
       <NOTNULL/>
       <DEFAULT value=""/>
     </field>
+    <field name="msNumPlurals" type="I" size="10">
+      <NOTNULL/>
+      <DEFAULT value="2"/>
+    </field>
+    <field name="msPluralRule" type="C" size="255">
+      <NOTNULL/>
+      <DEFAULT value="(n != 1)"/>
+    </field>
   </table>
   <table name="MultilingualPageRelations">
     <field name="mpRelationID" type="I" size="10">

--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -246,7 +246,11 @@
     <field name="msgid" type="X">
         <NOTNULL/>
     </field>
+    <field name="msgidPlural" type="X">
+    </field>
     <field name="msgstr" type="X">
+    </field>
+    <field name="msgstrPlurals" type="X">
     </field>
     <field name="context" type="X">
     </field>

--- a/web/concrete/controllers/single_page/dashboard/system/multilingual/translate_interface.php
+++ b/web/concrete/controllers/single_page/dashboard/system/multilingual/translate_interface.php
@@ -73,8 +73,8 @@ class TranslateInterface extends DashboardPageController
                 foreach($list as $section) {
                     if($section->getLocale() != $defaultSourceLocale) {
                         // now we load the translations that currently exist for each section
-                        $translations = $extractor->mergeTranslationsWithSectionFile($section, $translations);
-                        $translations = $extractor->mergeTranslationsWithCore($section, $translations);
+                        $extractor->mergeTranslationsWithSectionFile($section, $translations);
+                        $extractor->mergeTranslationsWithCore($section, $translations);
                         $extractor->saveSectionTranslationsToFile($section, $translations);
     
                         // now that we've updated the translation file, we take all the translations and
@@ -95,7 +95,7 @@ class TranslateInterface extends DashboardPageController
                 foreach($list as $section) {
                     if($section->getLocale() != $defaultSourceLocale) {
                         $translations = $section->getSectionInterfaceTranslations();
-                        $translations = $extractor->mergeTranslationsWithSectionFile($section, $translations);
+                        $extractor->mergeTranslationsWithSectionFile($section, $translations);
                         $extractor->saveSectionTranslationsToFile($section, $translations);
                     }
                 }

--- a/web/concrete/controllers/single_page/dashboard/system/multilingual/translate_interface.php
+++ b/web/concrete/controllers/single_page/dashboard/system/multilingual/translate_interface.php
@@ -75,6 +75,7 @@ class TranslateInterface extends DashboardPageController
                         // now we load the translations that currently exist for each section
                         $extractor->mergeTranslationsWithSectionFile($section, $translations);
                         $extractor->mergeTranslationsWithCore($section, $translations);
+                        $extractor->mergeTranslationsWithPackages($section, $translations);
                         $extractor->saveSectionTranslationsToFile($section, $translations);
     
                         // now that we've updated the translation file, we take all the translations and

--- a/web/concrete/src/Multilingual/Page/Section/Section.php
+++ b/web/concrete/src/Multilingual/Page/Section/Section.php
@@ -473,10 +473,10 @@ class Section extends Page
     {
         $translations = new Translations();
         $db = \Database::get();
-        $r = $db->query('select mtID, (if(mt.msgstr = "", 0, 1)) as completed from MultilingualTranslations mt where mtSectionID = ? order by completed asc, msgid asc', array($this->getCollectionID()));
+        $r = $db->query('select * from MultilingualTranslations mt where mtSectionID = ? order by if(mt.msgstr = "", 0, 1) asc, msgid asc', array($this->getCollectionID()));
         while ($row = $r->fetch()) {
-            $t = Translation::getByID($row['mtID']);
-            if (is_object($t)) {
+            $t = Translation::getByRow($row);
+            if (isset($t)) {
                 $translations[] = $t;
             }
         }

--- a/web/concrete/src/Multilingual/Page/Section/Section.php
+++ b/web/concrete/src/Multilingual/Page/Section/Section.php
@@ -1,6 +1,6 @@
 <?php
-
 namespace Concrete\Core\Multilingual\Page\Section;
+
 use Concrete\Core\Page\Page;
 use Database;
 use Concrete\Core\Multilingual\Page\Event;
@@ -12,7 +12,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 class Section extends Page
 {
-
     /**
      * @var string
      */
@@ -61,6 +60,7 @@ class Section extends Page
             $obj = parent::getByID($cID, $cvID, '\Concrete\Core\Multilingual\Page\Section\Section');
             $obj->msLanguage = $r['msLanguage'];
             $obj->msCountry = $r['msCountry'];
+
             return $obj;
         }
 
@@ -82,8 +82,10 @@ class Section extends Page
             $obj = parent::getByID($r['cID'], 'RECENT', '\Concrete\Core\Multilingual\Page\Section\Section');
             $obj->msLanguage = $r['msLanguage'];
             $obj->msCountry = $r['msCountry'];
+
             return $obj;
         }
+
         return false;
     }
 
@@ -103,11 +105,12 @@ class Section extends Page
             $obj = parent::getByID($r['cID'], 'RECENT', '\Concrete\Core\Multilingual\Page\Section\Section');
             $obj->msLanguage = $r['msLanguage'];
             $obj->msCountry = $r['msCountry'];
+
             return $obj;
         }
+
         return false;
     }
-
 
     /**
      * gets the MultilingualSection object for the current section of the site
@@ -122,6 +125,7 @@ class Section extends Page
                 $lang = self::getBySectionOfSite($c);
             }
         }
+
         return $lang;
     }
 
@@ -136,6 +140,7 @@ class Section extends Page
             }
         }
         $section = static::getByLanguage($explode[0]);
+
         return $section;
     }
 
@@ -173,6 +178,7 @@ class Section extends Page
         if ($this->getCountry()) {
             $locale .= '_' . $this->getCountry();
         }
+
         return $locale;
     }
 
@@ -186,6 +192,7 @@ class Section extends Page
         } catch (Exception $e) {
             $text = $this->msLanguage;
         }
+
         return $text;
     }
 
@@ -230,11 +237,11 @@ class Section extends Page
                 $pde = new Event($page);
                 $pde->setLocale($ms->getLocale());
                 \Events::dispatch('on_multilingual_page_relate', $pde);
+
                 return $mpRelationID;
             }
         }
     }
-
 
     public static function unregisterPage($page)
     {
@@ -312,6 +319,7 @@ class Section extends Page
             'select mpRelationID from MultilingualPageRelations where cID = ?',
             array($page->getCollectionID())
         );
+
         return $mpRelationID > 0;
     }
 
@@ -350,11 +358,10 @@ class Section extends Page
                             $mpRelationID,
                             $oldPage->getCollectionID(),
                             $msx->getLanguage(),
-                            $msx->getLocale()
+                            $msx->getLocale(),
                         )
                     );
                 }
-
             }
             $v = array($mpRelationID, $newPage->getCollectionID(), $ms->getLocale());
             $cID = $db->GetOne(
@@ -374,8 +381,6 @@ class Section extends Page
             \Events::dispatch('on_multilingual_page_relate', $pde);
         }
     }
-
-
 
     public static function isMultilingualSection($cID)
     {
@@ -422,6 +427,7 @@ class Section extends Page
         if (!$ids) {
             $ids = array();
         }
+
         return $ids;
     }
 
@@ -437,6 +443,7 @@ class Section extends Page
                 }
             }
         }
+
         return $pages;
     }
 
@@ -447,9 +454,10 @@ class Section extends Page
     {
         $db = Database::get();
         $ids = static::getIDList();
-        $locale = explode('_' , $this->getLocale());
+        $locale = explode('_', $this->getLocale());
         if (in_array($page->getCollectionID(), $ids)) {
             $cID = $db->GetOne('select cID from MultilingualSections where msLanguage = ? and msCountry = ?', array($locale[0], $locale[1]));
+
             return $cID;
         }
         $mpRelationID = $db->GetOne(
@@ -461,6 +469,7 @@ class Section extends Page
                 'select cID from MultilingualPageRelations where mpRelationID = ? and mpLocale = ?',
                 array($mpRelationID, $this->getLocale())
             );
+
             return $cID;
         }
     }
@@ -480,7 +489,7 @@ class Section extends Page
                 $translations[] = $t;
             }
         }
+
         return $translations;
     }
-
 }

--- a/web/concrete/src/Multilingual/Page/Section/Section.php
+++ b/web/concrete/src/Multilingual/Page/Section/Section.php
@@ -26,12 +26,12 @@ class Section extends Page
     /**
      * @var int
      */
-    protected $numPlurals;
+    protected $msNumPlurals;
 
     /**
      * @var string
      */
-    protected $pluralRule;
+    protected $msPluralRule;
 
     public static function assign($c, $language, $country, $numPlurals = null, $pluralRule = '')
     {
@@ -520,6 +520,8 @@ class Section extends Page
     public function getSectionInterfaceTranslations()
     {
         $translations = new Translations();
+        $translations->setLanguage($this->getLocale());
+        $translations->setPluralForms($this->msNumPlurals, $this->msPluralRule);
         $db = \Database::get();
         $r = $db->query('select * from MultilingualTranslations mt where mtSectionID = ? order by if(mt.msgstr = "", 0, 1) asc, msgid asc', array($this->getCollectionID()));
         while ($row = $r->fetch()) {

--- a/web/concrete/src/Multilingual/Page/Section/Translation.php
+++ b/web/concrete/src/Multilingual/Page/Section/Translation.php
@@ -1,12 +1,10 @@
 <?php
-
 namespace Concrete\Core\Multilingual\Page\Section;
 
 defined('C5_EXECUTE') or die("Access Denied.");
 
 class Translation extends \Gettext\Translation
 {
-
     public function getID()
     {
         return $this->mtID;
@@ -16,26 +14,64 @@ class Translation extends \Gettext\Translation
     {
         $db = \Database::get();
         $db->update('MultilingualTranslations', array(
-            'msgstr' => $msgstr
+            'msgstr' => $msgstr,
         ), array('mtID' => $this->mtID));
         $this->setTranslation($msgstr);
     }
 
-    public static function getByID($mtID)
+    public static function getByRow($row)
     {
-        $db = \Database::get();
-        $r = $db->query('select  * from MultilingualTranslations mt where mtID = ?', array($mtID));
-        $row = $r->fetch();
+        $result = null;
         if ($row && $row['mtID']) {
-            $t = new Translation();
-            $t->mtID = $row['mtID'];
-            $t->mtSectionID = $row['mtSectionID'];
-            $t->setOriginal($row['msgid']);
-            $t->setTranslation($row['msgstr']);
-            return $t;
+            $result = new Translation($row['context'], $row['msgid'], $row['msgidPlural']);
+            $result->mtID = $row['mtID'];
+            $result->mtSectionID = $row['mtSectionID'];
+            $result->setTranslation($row['msgstr']);
+            if (isset($row['comments'])) {
+                foreach (explode("\n", $row['comments']) as $comment) {
+                    $result->addExtractedComment($comment);
+                }
+            }
+            if ($result->hasPlural() && isset($row['msgstrPlurals'])) {
+                foreach (explode("\x00", $row['msgstrPlurals']) as $pluralIndex => $plural) {
+                    $result->setPluralTranslation($plural, $pluralIndex);
+                }
+            }
+            if (isset($row['reference'])) {
+                foreach (explode("\n", $row['reference']) as $reference) {
+                    if ($reference !== '') {
+                        $line = null;
+                        $p = strrpos($reference, ':');
+                        if ($p) {
+                            $s = substr($reference, $p + 1);
+                            if (preg_match('/^\d+$/', $s)) {
+                                $line = (int) $s;
+                                $reference = substr($reference, 0, $p);
+                            }
+                        }
+                        $result->addReference($reference, $line);
+                    }
+                }
+            }
+            if (isset($row['flags'])) {
+                foreach (explode("\n", $row['flags']) as $flag) {
+                    if ($flag !== '') {
+                        $result->addFlag($flag);
+                    }
+                }
+            }
         }
+
+        return $result;
     }
 
+    public static function getByID($mtID)
+    {
+        $result = null;
+        $db = \Database::get();
+        $r = $db->query('select  * from MultilingualTranslations where mtID = ?', array($mtID));
+        $row = $r->fetch();
 
-
+        return self::getByRow($row);
+    }
 }

--- a/web/concrete/src/Multilingual/Page/Section/Translation.php
+++ b/web/concrete/src/Multilingual/Page/Section/Translation.php
@@ -10,13 +10,30 @@ class Translation extends \Gettext\Translation
         return $this->mtID;
     }
 
-    public function updateTranslation($msgstr)
+    public function updateTranslation($msgstr, $msgstrPlurals = array())
     {
+        $msgstr = (string) $msgstr;
+        $data = array(
+            'msgstr' => (string) $msgstr,
+            'msgstrPlurals' => null,
+            'updated' => \Core::make('helper/date')->toDB(),
+        );
+        if ($this->hasPlural()) {
+            if (!is_array($msgstrPlurals)) {
+                $msgstrPlurals = array();
+            }
+            if (!empty($msgstrPlurals)) {
+                $data['msgstrPlurals'] = implode("\x00", $msgstrPlurals);
+            }
+        }
         $db = \Database::get();
-        $db->update('MultilingualTranslations', array(
-            'msgstr' => $msgstr,
-        ), array('mtID' => $this->mtID));
+        $db->update('MultilingualTranslations', $data, array('mtID' => $this->mtID));
         $this->setTranslation($msgstr);
+        if ($this->hasPlural()) {
+            foreach ($msgstrPlurals as $pluralIndex => $plural) {
+                $this->setPluralTranslation($plural, $pluralIndex);
+            }
+        }
     }
 
     public static function getByRow($row)

--- a/web/concrete/src/Multilingual/Service/Extractor.php
+++ b/web/concrete/src/Multilingual/Service/Extractor.php
@@ -69,10 +69,10 @@ class Extractor
     {
         $po = DIR_LANGUAGES_SITE_INTERFACE . '/' . $section->getLocale() . '.po';
         $mo = DIR_LANGUAGES_SITE_INTERFACE . '/' . $section->getLocale() . '.mo';
-        if (file_exists($po)) {
+        if (is_file($po)) {
             unlink($po);
         }
-        if (file_exists($mo)) {
+        if (is_file($mo)) {
             unlink($mo);
         }
     }
@@ -80,7 +80,7 @@ class Extractor
     public function mergeTranslationsWithSectionFile(Section $section, Translations $translations)
     {
         $file = DIR_LANGUAGES_SITE_INTERFACE . '/' . $section->getLocale() . '.po';
-        if (file_exists($file)) {
+        if (is_file($file)) {
             $sectionTranslations = PoExtractor::fromFile($file);
             $translations->mergeWith($sectionTranslations, Translations::MERGE_ADD | self::MERGE_PLURAL);
         }
@@ -91,9 +91,10 @@ class Extractor
         // Now we're going to load the core translations.
         $poFile = DIR_LANGUAGES . '/' . $section->getLocale() . '/LC_MESSAGES/messages.po';
         $moFile = DIR_LANGUAGES . '/' . $section->getLocale() . '/LC_MESSAGES/messages.mo';
-        if (file_exists($poFile)) {
+        $coreTranslations = null;
+        if (is_file($poFile)) {
             $coreTranslations = PoExtractor::fromFile($poFile);
-        } elseif (file_exists($moFile)) {
+        } elseif (is_file($moFile)) {
             $coreTranslations = MoExtractor::fromFile($moFile);
         }
 
@@ -108,7 +109,7 @@ class Extractor
                 /* @var $translation \Gettext\Translation */
                 if (!$translation->hasTranslation()) {
                     $coreTranslation = $coreTranslations->find($translation);
-                    if ($coreTranslation && $translation->hasTranslation()) {
+                    if ($coreTranslation && $coreTranslation->hasTranslation()) {
                         $translation->mergeWith($coreTranslation, Translations::MERGE_PLURAL);
                     }
                 }
@@ -135,7 +136,7 @@ class Extractor
         if (!$empty) {
             MoGenerator::toFile($translations, $mo);
         } else {
-            if (file_exists($mo)) {
+            if (is_file($mo)) {
                 unlink($mo);
             }
         }

--- a/web/concrete/src/Multilingual/Service/Extractor.php
+++ b/web/concrete/src/Multilingual/Service/Extractor.php
@@ -1,6 +1,6 @@
 <?php
-
 namespace Concrete\Core\Multilingual\Service;
+
 use Concrete\Attribute\Select\Option as SelectAttributeOption;
 use Concrete\Core\Attribute\Key\Key as AttributeKey;
 use Concrete\Core\Attribute\Set as AttributeSet;
@@ -44,24 +44,24 @@ class Extractor
             DIR_APPLICATION . '/' . DIRNAME_PAGE_TYPES,
             DIR_APPLICATION . '/' . DIRNAME_PAGES,
             DIR_APPLICATION . '/' . DIRNAME_THEMES,
-            DIR_APPLICATION . '/' . DIRNAME_VIEWS
+            DIR_APPLICATION . '/' . DIRNAME_VIEWS,
         );
 
         $files = array();
-        foreach($directories as $directory) {
+        foreach ($directories as $directory) {
             if (!is_dir($directory)) {
                 continue;
             }
             $directoryIterator = new \RecursiveDirectoryIterator($directory);
             $iterator = new \RecursiveIteratorIterator($directoryIterator);
             $results = new \RegexIterator($iterator, '/^.+\.php$/i', \RecursiveRegexIterator::GET_MATCH);
-            foreach($results as $result) {
+            foreach ($results as $result) {
                 $files[] = $result[0];
             }
         }
 
         $translations = new Translations();
-        foreach($files as $file) {
+        foreach ($files as $file) {
             $fileTranslations = Translations::fromPhpCodeFile($file);
             $translations->mergeWith($fileTranslations);
         }
@@ -85,6 +85,7 @@ class Extractor
         $translations->mergeWith(Group::exportTranslations());
         $translations->mergeWith(GroupSet::exportTranslations());
         $translations->mergeWith(SelectAttributeOption::exportTranslations());
+
         return $translations;
     }
 
@@ -124,7 +125,7 @@ class Extractor
         $moFile = DIR_LANGUAGES . '/' . $section->getLocale() . '/LC_MESSAGES/messages.mo';
         if (file_exists($poFile)) {
             $coreTranslations = Po::fromFile($poFile);
-        } else if (file_exists($moFile)) {
+        } elseif (file_exists($moFile)) {
             $coreTranslations = Mo::fromFile($moFile);
         }
 
@@ -136,7 +137,7 @@ class Extractor
 
             // This is actually much faster than unsetting the matching translation from the existing translations object
 
-            foreach($translations as $key => $translation) {
+            foreach ($translations as $key => $translation) {
                 if (!$translation->getTranslation()) {
                     if (!$coreTranslations->find($translation->getContext(), $translation->getOriginal())) {
                         $returnTranslations[] = $translation;
@@ -145,6 +146,7 @@ class Extractor
                     $returnTranslations[] = $translation;
                 }
             }
+
             return $returnTranslations;
         }
 
@@ -180,11 +182,11 @@ class Extractor
     {
         $db = \Database::get();
         $db->delete('MultilingualTranslations', array('mtSectionID' => $section->getCollectionID()));
-        foreach($translations as $translation) {
+        foreach ($translations as $translation) {
             $comments = implode(':', $translation->getComments());
             $references = $translation->getReferences();
             $refs = '';
-            foreach($references as $reference) {
+            foreach ($references as $reference) {
                 $refs = implode(':', $reference) . "\n";
             }
             $db->insert('MultilingualTranslations', array(
@@ -193,7 +195,7 @@ class Extractor
                 'msgstr' => $translation->getTranslation(),
                 'context' => $translation->getContext(),
                 'comments' => $comments,
-                'reference' => $refs
+                'reference' => $refs,
             ));
         }
     }
@@ -213,7 +215,7 @@ class Extractor
         if ($data['messageCount'] > 0) {
             $data['completionPercentage'] = round(($data['translatedCount'] / $data['messageCount']) * 100);
         }
+
         return $data;
     }
-
 }

--- a/web/concrete/src/Multilingual/Service/Extractor.php
+++ b/web/concrete/src/Multilingual/Service/Extractor.php
@@ -83,7 +83,7 @@ class Extractor
         $file = DIR_LANGUAGES_SITE_INTERFACE . '/' . $section->getLocale() . '.po';
         if (is_file($file)) {
             $sectionTranslations = PoExtractor::fromFile($file);
-            $translations->mergeWith($sectionTranslations, Translations::MERGE_ADD | self::MERGE_PLURAL);
+            $translations->mergeWith($sectionTranslations, Translations::MERGE_ADD | Translations::MERGE_PLURAL);
         }
     }
 

--- a/web/concrete/src/Multilingual/Service/Extractor.php
+++ b/web/concrete/src/Multilingual/Service/Extractor.php
@@ -162,22 +162,22 @@ class Extractor
                 'context' => $translation->getContext(),
             );
             $plurals = $translation->getPluralTranslation();
-            if(!empty($plurals)) {
+            if (!empty($plurals)) {
                 $data['msgstrPlurals'] = implode("\x00", $plurals);
             }
             $comments = $translation->getExtractedComments();
-            if(!empty($plurals)) {
+            if (!empty($plurals)) {
                 $data['comments'] = implode("\n", $comments);
             }
             $references = $translation->getReferences();
-            if(!empty($references)) {
+            if (!empty($references)) {
                 $data['reference'] = '';
                 foreach ($translation->getReferences() as $reference) {
                     $data['reference'] .= implode(':', $reference) . "\n";
                 }
             }
             $flags = $translation->getFlags();
-            if(!empty($flags)) {
+            if (!empty($flags)) {
                 $data['flags'] =  implode("\n", $flags);
             }
             $db->insert('MultilingualTranslations', $data);

--- a/web/concrete/src/Multilingual/Service/Extractor.php
+++ b/web/concrete/src/Multilingual/Service/Extractor.php
@@ -11,8 +11,8 @@ use Concrete\Core\Permission\Access\Entity\Type as PermissionAccessEntityType;
 use Concrete\Core\Permission\Key\Key as PermissionKey;
 use Concrete\Core\User\Group\Group;
 use Concrete\Core\User\Group\GroupSet;
-use Gettext\Extractors\Mo;
-use Gettext\Extractors\Po;
+use Gettext\Extractors\Mo as MoExtractor;
+use Gettext\Extractors\Po as PoExtractor;
 use Gettext\Translations;
 use Gettext\Extractors\PhpCode;
 use Gettext\Generators\Po as PoGenerator;
@@ -111,7 +111,7 @@ class Extractor
     {
         $file = DIR_LANGUAGES_SITE_INTERFACE . '/' . $section->getLocale() . '.po';
         if (file_exists($file)) {
-            $sectionTranslations = Po::fromFile($file);
+            $sectionTranslations = PoExtractor::fromFile($file);
             $translations->mergeWith($sectionTranslations, Translations::MERGE_ADD);
         }
 
@@ -124,9 +124,9 @@ class Extractor
         $poFile = DIR_LANGUAGES . '/' . $section->getLocale() . '/LC_MESSAGES/messages.po';
         $moFile = DIR_LANGUAGES . '/' . $section->getLocale() . '/LC_MESSAGES/messages.mo';
         if (file_exists($poFile)) {
-            $coreTranslations = Po::fromFile($poFile);
+            $coreTranslations = PoExtractor::fromFile($poFile);
         } elseif (file_exists($moFile)) {
-            $coreTranslations = Mo::fromFile($moFile);
+            $coreTranslations = MoExtractor::fromFile($moFile);
         }
 
         if (isset($coreTranslations)) {

--- a/web/concrete/src/Updater/Migrations/Migrations/Version5732.php
+++ b/web/concrete/src/Updater/Migrations/Migrations/Version5732.php
@@ -16,6 +16,19 @@ class Version5732 extends AbstractMigration
     {
         $db = \Database::get();
         $db->Execute('DROP TABLE IF EXISTS PageStatistics');
+        $mt = $schema->getTable('MultilingualTranslations');
+        $mtsUpdated = false;
+        if(!$mt->hasColumn('msgidPlural')) {
+            $mt->addColumn('msgidPlural', 'text', array('notnull' => false));
+            $mtUpdated = true;
+        }
+        if(!$mt->hasColumn('msgstrPlurals')) {
+            $mt->addColumn('msgstrPlurals', 'text', array('notnull' => false));
+            $mtUpdated = true;
+        }
+        if($mtUpdated) {
+            $db->Execute("UPDATE MultilingualTranslations SET comments = REPLACE(comments, ':', '\\n') WHERE comments IS NOT NULL");
+        }
     }
 
     public function down(Schema $schema)

--- a/web/concrete/src/Updater/Migrations/Migrations/Version5732.php
+++ b/web/concrete/src/Updater/Migrations/Migrations/Version5732.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Schema\Schema;
 
 class Version5732 extends AbstractMigration
 {
-
     public function getName()
     {
         return '20150117000000';
@@ -18,15 +17,15 @@ class Version5732 extends AbstractMigration
         $db->Execute('DROP TABLE IF EXISTS PageStatistics');
         $mt = $schema->getTable('MultilingualTranslations');
         $mtsUpdated = false;
-        if(!$mt->hasColumn('msgidPlural')) {
+        if (!$mt->hasColumn('msgidPlural')) {
             $mt->addColumn('msgidPlural', 'text', array('notnull' => false));
             $mtUpdated = true;
         }
-        if(!$mt->hasColumn('msgstrPlurals')) {
+        if (!$mt->hasColumn('msgstrPlurals')) {
             $mt->addColumn('msgstrPlurals', 'text', array('notnull' => false));
             $mtUpdated = true;
         }
-        if($mtUpdated) {
+        if ($mtUpdated) {
             $db->Execute("UPDATE MultilingualTranslations SET comments = REPLACE(comments, ':', '\\n') WHERE comments IS NOT NULL");
         }
     }

--- a/web/concrete/src/Updater/Migrations/Migrations/Version5732.php
+++ b/web/concrete/src/Updater/Migrations/Migrations/Version5732.php
@@ -15,8 +15,38 @@ class Version5732 extends AbstractMigration
     {
         $db = \Database::get();
         $db->Execute('DROP TABLE IF EXISTS PageStatistics');
+        $ms = $schema->getTable('MultilingualSections');
+        $msUpdated = false;
+        if (!$ms->hasColumn('msPlurals')) {
+            $ms->addColumn('msNumPlurals', 'integer', array('notnull' => true, 'unsigned' => true, 'default' => 2));
+            $msUpdated = true;
+        }
+        if (!$ms->hasColumn('msPluralRule')) {
+            $ms->addColumn('msPluralRule', 'string', array('notnull' => true, 'length' => 255, 'default' => '(n != 1)'));
+            $msUpdated = true;
+        }
+        if ($msUpdated) {
+            $rs = $db->Execute('select cID, msLanguage, msCountry from MultilingualSections');
+            while ($row = $rs->FetchRow()) {
+                $locale = $row['msLanguage'];
+                if ($row['msCountry']) {
+                    $locale .= '_' . $row['msCountry'];
+                }
+                $localeInfo = \Gettext\Utils\Locales::getLocaleInfo($locale);
+                if ($localeInfo) {
+                    $db->update(
+                        'MultilingualSections',
+                        array(
+                            'msNumPlurals' => $localeInfo['plurals'],
+                            'msPluralRule' => $localeInfo['pluralRule'],
+                        ),
+                        array('cID' => $row['cID'])
+                    );
+                }
+            }
+        }
         $mt = $schema->getTable('MultilingualTranslations');
-        $mtsUpdated = false;
+        $mtUpdated = false;
         if (!$mt->hasColumn('msgidPlural')) {
             $mt->addColumn('msgidPlural', 'text', array('notnull' => false));
             $mtUpdated = true;


### PR DESCRIPTION
## The Problem
Currently we have these processes that work on translatable strings:
- populate Transifex resources: this is done with [i18n.php](https://github.com/mlocati/concrete5-build/blob/master/i18n.php)
- extract dynamic strings from running instances on concrete5 5.6.x: this is done with [Localizer](https://github.com/mlocati/concrete5-localizer)
- extract dynamic strings from running instances on concrete5 5.7.x: this is done with [Multilingual/Service/Extractor](https://github.com/concrete5/concrete5-5.7.0/blob/develop/web/concrete/src/Multilingual/Service/Extractor.php)

This is quite a mess to keep all these systems updated.

## The Solution
Let's introduce a common library to handle translations: the whole new **[concrete5 Translation Library](https://github.com/mlocati/concrete5-translation-library)** :wink:
This library can extract strings from running instances (replaces Localizer and Multilingual/Service/Extractor), as well as from directories (replaces i18n.php)

I tested it from concrete5 5.5.2 to concrete5 5.7.git and everything seems to be fine.

I worked with @oscarotero to fix some minor issues of his great [Gettext library](https://github.com/oscarotero/Gettext), but something still need some minor refinement. So, for the moment don't merge this PR.