### PR TITLE
allow a page to be passed to getServiceLink

### DIFF
--- a/web/concrete/src/Sharing/ShareThisPage/Service.php
+++ b/web/concrete/src/Sharing/ShareThisPage/Service.php
@@ -16,9 +16,11 @@ class Service extends SocialNetworkService
         }
     }
 
-    public function getServiceLink()
+    public function getServiceLink(\Page $c = null)
     {
-        $c = \Page::getCurrentPage();
+        if (!is_object($c)) {
+            $c = \Page::getCurrentPage();
+        }
         if (is_object($c) && !$c->isError()) {
             $url = urlencode($c->getCollectionLink(true));
             switch($this->getHandle()) {


### PR DESCRIPTION
we're wanting to have a 'share this' on each instance of a page
in a page list template and thought it would be nice to use the code
that is in core already, but this would only share the page the user
is currently viewing. This PR would allow for a custom page to
optionally be passed in to override this behaviour.