### PR TITLE
Fix cookie config

### DIFF
--- a/web/concrete/config/concrete.php
+++ b/web/concrete/config/concrete.php
@@ -557,11 +557,11 @@ return array(
         'handler'      => 'file',
         'max_lifetime' => 7200,
         'cookie'       => array(
-            'path'     => '',
-            'lifetime' => 7200,
-            'domain'   => '',
-            'secure'   => false,
-            'httponly' => false
+            'cookie_path'     => '',
+            'cookie_lifetime' => 7200,
+            'cookie_domain'   => '',
+            'cookie_secure'   => false,
+            'cookie_httponly' => false
         )
     ),
 

--- a/web/concrete/src/Session/Session.php
+++ b/web/concrete/src/Session/Session.php
@@ -18,23 +18,21 @@ class Session
         if ($app->isRunThroughCommandLineInterface()) {
             $storage = new MockArraySessionStorage();
         } else {
+            $options = Config::get('concrete.session.cookie');
+            $options['gc_max_lifetime'] = Config::get('concrete.session.max_lifetime');
+            $handler = null;
             if (Config::get('concrete.session.handler') == 'database') {
                 $db = \Database::get();
-                $storage = new NativeSessionStorage(array(),
-                    new PdoSessionHandler($db->getWrappedConnection(), array(
+                $handler = new PdoSessionHandler($db->getWrappedConnection(), array(
                             'db_table' => 'Sessions',
                             'db_id_col' => 'sessionID',
                             'db_data_col' => 'sessionValue',
                             'db_time_col' => 'sessionTime'
                         )
-                    )
-                );
-            } else {
-                $storage = new NativeSessionStorage();
+                    );
             }
-            $options = Config::get('concrete.session.cookie');
-            $options['gc_max_lifetime'] = Config::get('concrete.session.max_lifetime');
-            $storage->setOptions($options);
+            $storage = new NativeSessionStorage($options,$handler);
+            unset($options,$handler);
         }
 
         $session = new SymfonySession($storage);


### PR DESCRIPTION
NativeSessionStorage need prefix “cookie_” in parameters.
see: 
http://api.symfony.com/2.6/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.html#method_setOptions
http://php.net/session.configuration