### PR TITLE
Authentication type only renders once

### DIFF
--- a/web/concrete/src/Authentication/AuthenticationType.php
+++ b/web/concrete/src/Authentication/AuthenticationType.php
@@ -390,7 +390,7 @@ class AuthenticationType extends Object
             $this->controller->view();
         }
         extract(array_merge($params, $this->controller->getSets()));
-        require_once($form_element->file);
+        require($form_element->file);
         $out = ob_get_contents();
         ob_end_clean();
         echo $out;


### PR DESCRIPTION
Fixed a bug only rendering a authentication type once (usefull when adding then to a page).

http://www.concrete5.org/developers/bugs/5-7-3-1/authentication-type-renders-only-once/