### PR TITLE
set context when loading translation from database

### DIFF
--- a/web/concrete/src/Multilingual/Page/Section/Translation.php
+++ b/web/concrete/src/Multilingual/Page/Section/Translation.php
@@ -32,6 +32,8 @@ class Translation extends \Gettext\Translation
             $t->mtSectionID = $row['mtSectionID'];
             $t->setOriginal($row['msgid']);
             $t->setTranslation($row['msgstr']);
+            $t->setContext($row['context']);
+
             return $t;
         }
     }


### PR DESCRIPTION
Currently we don't correctly set context when loading translations from db, resulting in duplicates when we merge database translations with extracted translations.

I think PR #1841 already fixes this, it is just a less intrusive fix in case that PR is not to be merged soon.