### PR TITLE
Fix to for page templates to be found in packages

### DIFF
--- a/web/concrete/bootstrap/configure.php
+++ b/web/concrete/bootstrap/configure.php
@@ -121,6 +121,7 @@ define('DIRNAME_WORKFLOW_ASSIGNMENTS', 'assignments');
 define('DIRNAME_REQUESTS', 'requests');
 define('DIRNAME_KEYS', 'keys');
 define('DIRNAME_PAGE_TYPES', 'page_types');
+define('DIRNAME_PAGE_TEMPLATES', 'page_templates');
 define('DIRNAME_PAGE_THEME', 'page_theme');
 define('DIRNAME_PAGE_THEME_CUSTOM', 'custom');
 define('DIRNAME_ELEMENTS', 'elements');

--- a/web/concrete/src/Foundation/Environment.php
+++ b/web/concrete/src/Foundation/Environment.php
@@ -88,7 +88,7 @@ class Environment {
 			DIR_FILES_CONTENT, 
 			DIR_FILES_THEMES, 
 			DIR_FILES_TOOLS, 
-			DIR_APPLICATION . '/' . DIRNAME_PAGE_TYPES, 
+			DIR_APPLICATION . '/' . DIRNAME_PAGE_TEMPLATES,
 			DIR_APPLICATION . '/' . DIRNAME_CLASSES);
 		foreach($check as $loc) {
 			if (is_dir($loc)) {

--- a/web/concrete/src/Page/View/PageView.php
+++ b/web/concrete/src/Page/View/PageView.php
@@ -85,13 +85,13 @@ class PageView extends View
                         $this->pkgHandle));
             } else {
                 $rec = $env->getRecord(
-                    DIRNAME_PAGE_TYPES . '/' . $this->c->getPageTypeHandle() . '.php',
-                    $this->pkgHandle);
+                    DIRNAME_PAGE_TEMPLATES . '/' . $this->c->getPageTypeHandle() . '.php',
+                    $this->pTemplatePkgHandle);
                 if ($rec->exists()) {
                     $this->setInnerContentFile(
                         $env->getPath(
-                            DIRNAME_PAGE_TYPES . '/' . $this->c->getPageTypeHandle() . '.php',
-                            $this->pkgHandle));
+                            DIRNAME_PAGE_TEMPLATES . '/' . $this->c->getPageTypeHandle() . '.php',
+                            $this->pTemplatePkgHandle));
                     $this->setViewTemplate(
                         $env->getPath(
                             DIRNAME_THEMES . '/' . $this->themeHandle . '/' . $this->controller->getThemeViewTemplate(),
@@ -214,6 +214,10 @@ class PageView extends View
         parent::constructView($page->getCollectionPath());
         if (!isset($this->pTemplateID)) {
             $this->pTemplateID = $this->c->getPageTemplateID();
+            $pto = $this->c->getPageTemplateObject();
+            if ($pto && $pto->getPackageID()) {
+                $this->pTemplatePkgHandle = $this->c->getPageTemplateObject()->getPackageHandle();
+            }
         }
         if (!isset($this->pThemeID)) {
             $this->pThemeID = $this->c->getPageTemplateID();


### PR DESCRIPTION
- Addition of new DIRNAME_PAGE_TEMPLATES define
- Addition of DIRNAME_PAGE_TEMPLATES to Environment overrides list
(removal of DIRNAME_PAGE_TYPES)
- Adjustment of PageView to look at page_templates and package when applicable
- New page_templates empty dir in /application
- Removal of defunct page_types folder from /application
