### PR TITLE
Localization improvements and fixes

### DIFF
--- a/web/concrete/composer.json
+++ b/web/concrete/composer.json
@@ -57,6 +57,6 @@
         "tedivm/stash": "0.12.1",
         "lusitanian/oauth": "~0.3",
         "oryzone/oauth-user-data": "~1.0@dev",
-        "mlocati/concrete5-translation-library": "1.*"
+        "mlocati/concrete5-translation-library": "1.0.4"
     }
 }

--- a/web/concrete/composer.json
+++ b/web/concrete/composer.json
@@ -57,6 +57,6 @@
         "tedivm/stash": "0.12.1",
         "lusitanian/oauth": "~0.3",
         "oryzone/oauth-user-data": "~1.0@dev",
-        "mlocati/concrete5-translation-library": "1.0.4"
+        "mlocati/concrete5-translation-library": "1.0.*"
     }
 }

--- a/web/concrete/composer.lock
+++ b/web/concrete/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "543eff7cf2088a114ece69dc4e8b3eb4",
+    "hash": "5bb2de2e6012dec8e19e6bc82a74aa46",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -915,16 +915,16 @@
         },
         {
             "name": "gettext/gettext",
-            "version": "v3.0",
+            "version": "v3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oscarotero/Gettext.git",
-                "reference": "e54627b820b9ff838934134ce403e22a7e86dd02"
+                "reference": "e6598d172881dd8eb6232d6321784a01fd6a47d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oscarotero/Gettext/zipball/e54627b820b9ff838934134ce403e22a7e86dd02",
-                "reference": "e54627b820b9ff838934134ce403e22a7e86dd02",
+                "url": "https://api.github.com/repos/oscarotero/Gettext/zipball/e6598d172881dd8eb6232d6321784a01fd6a47d7",
+                "reference": "e6598d172881dd8eb6232d6321784a01fd6a47d7",
                 "shasum": ""
             },
             "require": {
@@ -961,7 +961,7 @@
                 "po",
                 "translation"
             ],
-            "time": "2015-01-22 21:42:54"
+            "time": "2015-01-28 15:27:55"
         },
         {
             "name": "hautelook/phpass",
@@ -1481,20 +1481,20 @@
         },
         {
             "name": "mlocati/concrete5-translation-library",
-            "version": "1.0.1",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlocati/concrete5-translation-library.git",
-                "reference": "d26f7a338092110a2fc660cd9c4ed3cd1455cbca"
+                "reference": "dded8e9d1632b299ce3022f6549343f07e2b8966"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/d26f7a338092110a2fc660cd9c4ed3cd1455cbca",
-                "reference": "d26f7a338092110a2fc660cd9c4ed3cd1455cbca",
+                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/dded8e9d1632b299ce3022f6549343f07e2b8966",
+                "reference": "dded8e9d1632b299ce3022f6549343f07e2b8966",
                 "shasum": ""
             },
             "require": {
-                "gettext/gettext": "3.*",
+                "gettext/gettext": "3.1.*",
                 "php": ">=5.3.0"
             },
             "type": "library",
@@ -1527,7 +1527,7 @@
                 "translate",
                 "translation"
             ],
-            "time": "2015-01-27 13:17:52"
+            "time": "2015-01-28 15:52:06"
         },
         {
             "name": "mobiledetect/mobiledetectlib",

--- a/web/concrete/composer.lock
+++ b/web/concrete/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5bb2de2e6012dec8e19e6bc82a74aa46",
+    "hash": "81df73f8e38831c4bbac5ab3c5a9a923",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -1481,16 +1481,16 @@
         },
         {
             "name": "mlocati/concrete5-translation-library",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlocati/concrete5-translation-library.git",
-                "reference": "dded8e9d1632b299ce3022f6549343f07e2b8966"
+                "reference": "f9e122aee56fb1428b9a8279036fdc6b2cdc2cea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/dded8e9d1632b299ce3022f6549343f07e2b8966",
-                "reference": "dded8e9d1632b299ce3022f6549343f07e2b8966",
+                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/f9e122aee56fb1428b9a8279036fdc6b2cdc2cea",
+                "reference": "f9e122aee56fb1428b9a8279036fdc6b2cdc2cea",
                 "shasum": ""
             },
             "require": {
@@ -1527,7 +1527,7 @@
                 "translate",
                 "translation"
             ],
-            "time": "2015-01-28 15:52:06"
+            "time": "2015-01-30 07:57:32"
         },
         {
             "name": "mobiledetect/mobiledetectlib",

--- a/web/concrete/single_pages/dashboard/system/multilingual/translate_interface.php
+++ b/web/concrete/single_pages/dashboard/system/multilingual/translate_interface.php
@@ -47,7 +47,7 @@ if ($this->controller->getTask() == 'translate_po') { ?>
                 </div>
                 <ul class="list-group">
                     <? foreach($translations as $string) { ?>
-                        <li class="list-group-item <? if ($string->hasTranslation()) { ?>list-group-item-success<? } ?> clearfix" data-translation="<?=$string->getID()?>">
+                        <li class="list-group-item <? if ($string->hasTranslation()) { ?>list-group-item-success<? } ?> clearfix" data-translation="<?=$string->getRecordID()?>">
                             <span class="original">
                                 <?=$string->getOriginal()?>
                             </span>
@@ -65,15 +65,15 @@ if ($this->controller->getTask() == 'translate_po') { ?>
                 <div class="panel-heading"><?=t('Translate')?></div>
                 <div class="panel-body">
                     <? foreach($translations as $string) { ?>
-                        <form method="post" class="translate-form" action="<?=$controller->action('save_translation')?>" data-form="<?=$string->getID()?>">
-                            <input type="hidden" name="mtID" value="<?=$string->getID()?>">
+                        <form method="post" class="translate-form" action="<?=$controller->action('save_translation')?>" data-form="<?=$string->getRecordID()?>">
+                            <input type="hidden" name="mtID" value="<?=$string->getRecordID()?>">
                             <div class="form-group">
-                                <label class="control-label" for="original-<?=$string->getID()?>"><?=t('Original String')?></label>
-                                <textarea class="form-control" disabled id="original-<?=$string->getID()?>" rows="8"><?=h($string->getOriginal())?></textarea>
+                                <label class="control-label" for="original-<?=$string->getRecordID()?>"><?=t('Original String')?></label>
+                                <textarea class="form-control" disabled id="original-<?=$string->getRecordID()?>" rows="8"><?=h($string->getOriginal())?></textarea>
                             </div>
                             <div class="form-group">
-                                <label class="control-label" for="translation-<?=$string->getID()?>"><?=t('Translation')?></label>
-                                <textarea class="form-control" name="msgstr" id="translation-<?=$string->getID()?>" rows="8"><?=h($string->getTranslation())?></textarea>
+                                <label class="control-label" for="translation-<?=$string->getRecordID()?>"><?=t('Translation')?></label>
+                                <textarea class="form-control" name="msgstr" id="translation-<?=$string->getRecordID()?>" rows="8"><?=h($string->getTranslation())?></textarea>
                             </div>
                             <button class="btn btn-primary" data-btn="save"><?=t('Save &amp; Continue')?></button>
                             <div class="spacer-row-3"></div>

--- a/web/concrete/src/Multilingual/Page/Section/Section.php
+++ b/web/concrete/src/Multilingual/Page/Section/Section.php
@@ -18,7 +18,6 @@ class Section extends Page
         return '\\Concrete\\Core\\Permission\\Response\\MultilingualSectionResponse';
     }
 
-
     public function getPermissionObjectKeyCategoryHandle()
     {
         return 'multilingual_section';
@@ -50,21 +49,21 @@ class Section extends Page
         $data = array(
             'cID' => $c->getCollectionID(),
             'msLanguage' => $language,
-            'msCountry' => $country
+            'msCountry' => $country,
         );
         $pluralRule = (string) $pluralRule;
-        if(empty($numPlurals) || ($pluralRule === '')) {
+        if (empty($numPlurals) || ($pluralRule === '')) {
             $locale = $language;
-            if($country !== '') {
+            if ($country !== '') {
                 $locale .= '_' . $country;
             }
             $localeInfo = \Gettext\Utils\Locales::getLocaleInfo($locale);
-            if($localeInfo) {
+            if ($localeInfo) {
                 $numPlurals = $localeInfo['plurals'];
                 $pluralRule = $localeInfo['pluralRule'];
             }
         }
-        if((!empty($numPlurals)) && ($pluralRule !== '')) {
+        if ((!empty($numPlurals)) && ($pluralRule !== '')) {
             $data['msNumPlurals'] = $numPlurals;
             $data['msPluralRule'] = $pluralRule;
         }
@@ -254,6 +253,32 @@ class Section extends Page
     public function getCountry()
     {
         return $this->msCountry;
+    }
+
+    /**
+     * Returns the number of plural forms
+     * @return int
+     * @example For Japanese: returns 1
+     * @example For English: returns 2
+     * @example For French: returns 2
+     * @example For Russian returns 3
+     */
+    public function getNumberOfPluralForms()
+    {
+        return (int) $this->msNumPlurals;
+    }
+
+    /**
+     * Returns the rule to determine which plural we should use (in gettext notation)
+     * @return string
+     * @example For Japanese: returns '0'
+     * @example For English: returns '(n != 1)'
+     * @example For French: returns '(n > 1)'
+     * @example For Russian returns '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)'
+     */
+    public function getPluralsRule()
+    {
+        return (string) $this->msPluralRule;
     }
 
     public static function registerPage($page)
@@ -532,9 +557,9 @@ class Section extends Page
     {
         $translations = new Translations();
         $translations->setLanguage($this->getLocale());
-        $translations->setPluralForms($this->msNumPlurals, $this->msPluralRule);
+        $translations->setPluralForms($this->getNumberOfPluralForms(), $this->getPluralsRule());
         $db = \Database::get();
-        $r = $db->query('select * from MultilingualTranslations mt where mtSectionID = ? order by if(mt.msgstr = "", 0, 1) asc, msgid asc', array($this->getCollectionID()));
+        $r = $db->query('select * from MultilingualTranslations mt where mtSectionID = ? order by mtID', array($this->getCollectionID()));
         while ($row = $r->fetch()) {
             $t = Translation::getByRow($row);
             if (isset($t)) {

--- a/web/concrete/src/Multilingual/Page/Section/Translation.php
+++ b/web/concrete/src/Multilingual/Page/Section/Translation.php
@@ -5,7 +5,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 class Translation extends \Gettext\Translation
 {
-    public function getID()
+    public function getRecordID()
     {
         return $this->mtID;
     }
@@ -88,11 +88,11 @@ class Translation extends \Gettext\Translation
         $r = $db->query('select mtID from MultilingualTranslations mt where msgid = ?', array($msgid));
         $row = $r->fetch();
         if ($row && $row['mtID']) {
-            return static::getByID($row['mtID']);
+            return static::getByRecordID($row['mtID']);
         }
     }
-    
-    public static function getByID($mtID)
+
+    public static function getByRecordID($mtID)
     {
         $result = null;
         $db = \Database::get();

--- a/web/concrete/src/Multilingual/Service/Extractor.php
+++ b/web/concrete/src/Multilingual/Service/Extractor.php
@@ -37,11 +37,14 @@ class Extractor
             if (is_dir(DIR_APPLICATION.'/'.$dirname)) {
                 foreach ($parsers as $parser) {
                     /* @var $parser \C5TL\Parser */
-                    $parser->parseDirectory(
-                        DIR_APPLICATION.'/'.$dirname,
-                        DIRNAME_APPLICATION.'/'.$dirname,
-                        $translations
-                    );
+                    $fullDirname = DIR_APPLICATION.'/'.$dirname;
+                    if (is_dir($fullDirname)) {
+                        $parser->parseDirectory(
+                            $fullDirname,
+                            DIRNAME_APPLICATION.'/'.$dirname,
+                            $translations
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Upgrade gettext/gettext to v3.1
- Rename \Concrete\Core\Multilingual\Page\Section\Translation::getID to getRecordID since \Gettext\Translation introduced getID itself in 3.1
- Save multilingual sections accordingly to the section plural rules
- Fix extracting translations from not-existing folders (before we had an Exception)