### PR TITLE
use request object to build BASE_URL, support trusted proxies

### DIFF
--- a/web/concrete/bootstrap/configure.php
+++ b/web/concrete/bootstrap/configure.php
@@ -75,19 +75,9 @@ define('NAMESPACE_SEGMENT_VENDOR', 'Concrete');
 
 /**
  * ----------------------------------------------------------------------------
- * Base URL, Relative Directory and URL rewriting
+ * Relative Directory and URL rewriting
  * ----------------------------------------------------------------------------
  */
-if (!defined('BASE_URL')) {
-    if(isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) {
-        define('BASE_URL', 'https://' . $_SERVER['HTTP_HOST']);
-    } else if (isset($_SERVER['HTTP_HOST'])) {
-        define('BASE_URL', 'http://' . $_SERVER['HTTP_HOST']);
-    } else {
-        define('BASE_URL', false);
-    }
-}
-
 if (!defined('DIR_REL')) {
     $pos = stripos($_SERVER['SCRIPT_NAME'], DISPATCHER_FILENAME);
     if($pos > 0) { //we do this because in CLI circumstances (and some random ones) we would end up with index.ph instead of index.php

--- a/web/concrete/bootstrap/start.php
+++ b/web/concrete/bootstrap/start.php
@@ -179,6 +179,22 @@ include DIR_APPLICATION . '/bootstrap/app.php';
  * ----------------------------------------------------------------------------
  */
 $request = Request::getInstance();
+$request->setTrustedProxies($config->get('app.trusted_proxies', array()));
+
+if ($config->get('app.trusted_headers')) {
+    foreach ($config->get('app.trusted_headers') as $key => $value) {
+        Request::setTrustedHeaderName($key, $value);
+    }
+}
+
+/**
+ * ----------------------------------------------------------------------------
+ * Define BASE_URL
+ * ----------------------------------------------------------------------------
+ */
+if (!defined('BASE_URL')) {
+    define('BASE_URL', $request->getSchemeAndHttpHost());
+}
 
 /**
  * ----------------------------------------------------------------------------


### PR DESCRIPTION
This allows support for header like HTTP_X_FORWARDED_HOST to build a correct BASE_URL behind a reverse proxy serving with a different Host.

I had to move BASE_URL definition outside configure.php because I need autoloading and config  access.