### PR TITLE
More defensive clipboard block loading

### DIFF
--- a/web/concrete/blocks/core_scrapbook_display/controller.php
+++ b/web/concrete/blocks/core_scrapbook_display/controller.php
@@ -56,8 +56,9 @@ class Controller extends BlockController
     public function on_page_view($page)
     {
         $b = Block::getByID($this->bOriginalID);
-        $bc = $b->getInstance();
-        if (method_exists($bc, 'on_page_view')) {
+        $bc = ($b) ? $b->getInstance() : false;
+
+        if ($bc && method_exists($bc, 'on_page_view')) {
             $bc->on_page_view($page);
         }
     }
@@ -65,9 +66,12 @@ class Controller extends BlockController
     public function outputAutoHeaderItems()
     {
         $b = Block::getByID($this->bOriginalID);
-        $b = $this->getBlockObject();
-        $bvt = new BlockViewTemplate($b);
-        $bvt->registerTemplateAssets();
+        if ($b) {
+            $b = $this->getBlockObject();
+            $bvt = new BlockViewTemplate($b);
+            $bvt->registerTemplateAssets();
+        }
+
     }
 
 }


### PR DESCRIPTION
The uninstall of blocks sometimes leaves the clipboard in a state
where getInstance() calls on non-objects breaks pages (with no way
to resolve it via the interface).

This adds some extra checking to check if block objects are in fact real
objects.