### PR TITLE
Fixed form submit anchor position

### DIFF
--- a/web/concrete/blocks/form/controller.php
+++ b/web/concrete/blocks/form/controller.php
@@ -477,7 +477,7 @@ class Controller extends BlockController {
 					}
 				}
 				$c = Page::getCurrentPage();
-				header("Location: ".Loader::helper('navigation')->getLinkToCollection($c, true)."?surveySuccess=1&qsid=".$this->questionSetId."#".$this->questionSetId);
+				header("Location: ".Loader::helper('navigation')->getLinkToCollection($c, true)."?surveySuccess=1&qsid=".$this->questionSetId."#formblock".$this->bID);
 				exit;
 			}
 		}


### PR DESCRIPTION
When the form is successfully submitted, redirect to the correct anchor position.