### PR TITLE
fix multilingual browser detection redirection

### DIFF
--- a/web/concrete/src/Multilingual/Service/Detector.php
+++ b/web/concrete/src/Multilingual/Service/Detector.php
@@ -53,11 +53,11 @@ class Detector
             }
         }
 
-        if (Config::get('concrete.multilingual.use_browser_detected_language')) {
+        if (Config::get('concrete.multilingual.use_browser_detected_locale')) {
             $home = false;
             $locales =  \Punic\Misc::getBrowserLocales();
-            foreach($locales as $locale => $value) {
-                $home = Section::getByLocaleOrLanguage($value);
+            foreach (array_keys($locales) as $locale) {
+                $home = Section::getByLocaleOrLanguage($locale);
                 if ($home) {
                     break;
                 }


### PR DESCRIPTION
Currently we use a wrong config key and we pass accept-language quality value instead of locale to Section::getByLocaleOrLanguage 