### PR TITLE
Bug fix when adding new templates

### DIFF
--- a/web/concrete/src/Page/Theme/Theme.php
+++ b/web/concrete/src/Page/Theme/Theme.php
@@ -522,7 +522,7 @@ class Theme extends Object
                         if (in_array($f, SinglePage::getThemeableCorePages())) {
                             $type = PageThemeFile::TFTYPE_SINGLE_PAGE;
                         } else {
-                            if (in_array($fHandle, $pts)) {
+                            if (is_array($pts) && in_array($fHandle, $pts)) {
                                 $type = PageThemeFile::TFTYPE_PAGE_TEMPLATE_EXISTING;
                             } else {
                                 $type = PageThemeFile::TFTYPE_PAGE_TEMPLATE_NEW;


### PR DESCRIPTION
When adding a new template PHP file into a theme directory, then going to
dashboard->Pages and Themes->Page Templates, C5 was throwing an error,
complaining that $pts wasn’t an array. Testing if $pts is an array in
the condition on line 525 seems to fix this issue.