### PR TITLE
Localization fixes about package load state and cache handling

### DIFF
--- a/web/concrete/src/Application/Application.php
+++ b/web/concrete/src/Application/Application.php
@@ -244,6 +244,7 @@ class Application extends Container
                 }
             }
         }
+        Config::set('concrete.packages_loaded', true);
     }
 
     /**

--- a/web/concrete/src/Localization/Localization.php
+++ b/web/concrete/src/Localization/Localization.php
@@ -5,9 +5,8 @@ use Config;
 use Concrete\Core\Cache\Adapter\ZendCacheDriver;
 use Core;
 use Events;
-use \Zend\I18n\Translator\Translator;
-use \Punic\Data as PunicData;
-use CacheLocal;
+use Zend\I18n\Translator\Translator;
+use Punic\Data as PunicData;
 
 class Localization
 {
@@ -84,8 +83,8 @@ class Localization
                 }
             }
             // Package language files
-            $pkgList = CacheLocal::getEntry('pkgList', 1);
-            if (is_object($pkgList)) {
+            if (Config::get('concrete.packages_loaded') === true) {
+                $pkgList = \Concrete\Core\Package\PackageList::get();
                 foreach ($pkgList->getPackages() as $pkg) {
                     $pkg->setupPackageLocalization($locale, $this->translate);
                 }

--- a/web/concrete/src/Localization/Localization.php
+++ b/web/concrete/src/Localization/Localization.php
@@ -198,6 +198,8 @@ class Localization
      */
     public static function clearCache()
     {
+        $locale = static::activeLocale();
         self::getCache()->flush();
+        static::changeLocale($locale);
     }
 }


### PR DESCRIPTION
- Store package load state in config, don't rely on cache (it may be disabled)
- Make sure we reload the localization files when we clear the localization cache