### PR TITLE
Add Index to value in atNumber

### DIFF
--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -4754,6 +4754,9 @@
     <field name="value" type="N" size="14.4">
       <default value="0"/>
     </field>
+    <index name="value">
+      <col>value</col>
+    </index>
   </table>
   <table name="atSelectSettings">
     <field name="akID" type="I" size="10">


### PR DESCRIPTION
The Number attribute value can sometimes be used for sorting and can
cause performance issues on larger datasets without an index.

Add index to `value` column in `atNumber` tabe for `Number` attribute