### PR TITLE
Restore the previous ordering of translations when translating

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/system/multilingual/translate_interface.php
+++ b/web/concrete/controllers/single_page/dashboard/system/multilingual/translate_interface.php
@@ -128,7 +128,7 @@ class TranslateInterface extends DashboardPageController
         $mtSectionID = intval($mtSectionID);
         $section = Section::getByID(intval($mtSectionID));
         if ($section) {
-            $translations = $section->getSectionInterfaceTranslations();
+            $translations = $section->getSectionInterfaceTranslations(true);
             $this->set('section', $section);
             $this->set('translations', $translations);
         } else {

--- a/web/concrete/src/Multilingual/Page/Section/Section.php
+++ b/web/concrete/src/Multilingual/Page/Section/Section.php
@@ -550,16 +550,23 @@ class Section extends Page
     }
 
     /**
-     * @param Section $section
-     * @return \Concrete\Core\Multilingual\Page\Section\Translation[] $translations
+     * Loads the translations of this multilingual section
+     * @param bool $untranslatedFirst Set to true to have untranslated strings first
+     * @return \Gettext\Translations
      */
-    public function getSectionInterfaceTranslations()
+    public function getSectionInterfaceTranslations($untranslatedFirst = false)
     {
         $translations = new Translations();
         $translations->setLanguage($this->getLocale());
         $translations->setPluralForms($this->getNumberOfPluralForms(), $this->getPluralsRule());
         $db = \Database::get();
-        $r = $db->query('select * from MultilingualTranslations mt where mtSectionID = ? order by mtID', array($this->getCollectionID()));
+        $r = $db->query(
+            "select *
+            from MultilingualTranslations
+            where mtSectionID = ?
+            order by ".($untranslatedFirst ? "if(ifnull(msgstr, '') = '', 0, 1), " : "")."mtID",
+            array($this->getCollectionID())
+        );
         while ($row = $r->fetch()) {
             $t = Translation::getByRow($row);
             if (isset($t)) {


### PR DESCRIPTION
In #1841 I changed the order of the loaded translations, since in the generated .po files it's better to keep the original order.
BTW, IMHO it's better to keep the untranslated strings at top in the concrete5 UI (at last until *someone* - like me - implements a more complete translators interface :wink:)