### PR TITLE
Fix the call to undefined function

### DIFF
--- a/web/concrete/src/User/Group/Group.php
+++ b/web/concrete/src/User/Group/Group.php
@@ -108,7 +108,7 @@ class Group extends Object implements \Concrete\Core\Permission\ObjectInterface
         $user_list = new UserList();
         $user_list->filterByGroup($this);
 
-        return $user_list->getUserIDs();
+        return $user_list->getResultIDs();
     }
 
     public function setPermissionsForObject($obj)


### PR DESCRIPTION
The function getUserIDs() is called getResultIDs() in the UserList class.