### PR TITLE
Fix problems with aliasing Conversation blocks (work in progress)

### DIFF
--- a/web/concrete/controllers/dialog/block/aliasing.php
+++ b/web/concrete/controllers/dialog/block/aliasing.php
@@ -38,7 +38,12 @@ class Aliasing extends BackendInterfaceBlockController
                         foreach ($_POST['cIDs'] as $cID) {
                             $nc = \Page::getByID($cID);
                             if (!$b->isAlias($nc)) {
-                                $b->alias($nc);
+                                $bt = $b->getBlockTypeObject();
+                                if ($bt->isCopiedWhenPropagated()) {
+                                    $b->duplicate($nc, true);
+                                } else {
+                                    $b->alias($nc);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
I was setting up a new page type, and I made some pages with the new page type. Then, I added a conversation block on a master collection of the page type. The pages that I already added has no conversation block. So, I added it on child pages from master collection. Finally, I posted some messages on conversation block. Strangely, same messages were appearing on each child page.

I found `$btCopyWhenPropagate` property on the controller of core conversation. So, we should duplicate a block instance of core conversation, instead of aliasing when copying it...Right? If so, I think there are additional issues related on this.

1. I think we should duplicate a conversation block when pasting from clipboard. How could we duplicate a block in the proxy block?
2. Should we duplicate a conversation block when we copy a collection version?
3. If we have to change the settings of conversation, we should go to all pages, and change the settings of all instances of the block. That is so annoying. I think we can treat all settings of conversation as global settings like file attachment settings.