### PR TITLE
Allow overriding core block controllers from package

### DIFF
--- a/web/concrete/src/Block/BlockType/BlockType.php
+++ b/web/concrete/src/Block/BlockType/BlockType.php
@@ -197,6 +197,10 @@ class BlockType
         $env = Environment::get();
         $txt = Loader::helper('text');
         $r = $env->getRecord(DIRNAME_BLOCKS . '/' . $btHandle . '/' . FILENAME_CONTROLLER);
+
+        // Replace $pkgHandle if overridden via environment
+        $r->pkgHandle and $pkgHandle = $r->pkgHandle;
+
         $prefix = $r->override ? true : $pkgHandle;
         $class = core_class('Block\\' . $txt->camelcase($btHandle) . '\\Controller', $prefix);
         return $class;

--- a/web/concrete/src/Foundation/Environment.php
+++ b/web/concrete/src/Foundation/Environment.php
@@ -158,6 +158,7 @@ class Environment {
 		}
 
 		$obj = new EnvironmentRecord();
+		$obj->pkgHandle = null;
 
 		if (!in_array($segment, $this->coreOverrides) && !$pkgHandle && !array_key_exists($segment, $this->coreOverridesByPackage)) {
 			$obj->file = DIR_BASE_CORE . '/' . $segment;
@@ -177,6 +178,7 @@ class Environment {
 
 		if (array_key_exists($segment, $this->coreOverridesByPackage)) {
 			$pkgHandle = $this->coreOverridesByPackage[$segment];
+			$obj->pkgHandle = $pkgHandle;
 		}
 
 		if (!in_array($pkgHandle, $this->corePackages)) {


### PR DESCRIPTION
I need to override the autonav block controller for a multisite package we're building. In 5.6 you could do that by calling `Environment::overrideCoreByPackage()` from for example the package controller on_start method, however in 5.7 that doesn't work anymore, at least for block controllers. 

So this fixes that, unless you guys have a better solution for me?