### PR TITLE
Cached Thumbnails (Issue #1945)

### DIFF
--- a/web/concrete/src/Legacy/ImageHelper.php
+++ b/web/concrete/src/Legacy/ImageHelper.php
@@ -89,17 +89,20 @@ class ImageHelper
         $fh = Loader::helper('file');
         if ($obj instanceof File) {
             $fr = $obj->getFileResource();
-            $image = \Image::load($fr->read());
             $fID = $obj->getFileID();
             $filename = md5(implode(':', array($fID, $maxWidth, $maxHeight, $crop, $fr->getTimestamp())))
                 . '.' . $fh->getExtension($fr->getPath());
         } else {
-            $image = \Image::open($obj);
             $filename = md5(implode(':', array($obj, $maxWidth, $maxHeight, $crop, filemtime($obj))))
                 . '.' . $fh->getExtension($obj);
         }
 
         if (!file_exists(Config::get('concrete.cache.directory') . '/' . $filename)) {
+            if ($obj instanceof File) {
+                $image = \Image::load($fr->read());
+            } else {
+                $image = \Image::open($obj);
+            }
             // create image there
             $this->create($image,
                           Config::get('concrete.cache.directory') . '/' . $filename,


### PR DESCRIPTION
Cached performance can be improved significantly by moving where the
$image variable is set to the conditional statement where the variable
is used.