### PR TITLE
Some proxies send unknown instead of IP address in headers.

### DIFF
--- a/web/concrete/src/Permission/IPService.php
+++ b/web/concrete/src/Permission/IPService.php
@@ -72,7 +72,7 @@ class IPService
             if (array_key_exists($index, $_SERVER) && is_string($_SERVER[$index])) {
                 foreach (explode(',', $_SERVER[$index]) as $ip) {
                     $ip = trim($ip);
-                    if (strlen($ip)) {
+                    if (strlen($ip) && (strcasecmp($ip, 'unknown') != 0)) {
                         $ip = new IPAddress($ip);
                         if ($ip->isPrivate()) {
                             $result = $ip;


### PR DESCRIPTION
Some proxy servers send unknown instead of the right IP address in the HTTP headers. It is also possible that they send it as a part of a list of IP addresses and the other addresses are valid in the list. When a proxy server send such a request, an error appears in concrete5 saying that there is an error with inet_pton(). This fix skips all entries with the text unknown.