### PR TITLE
Fix Elemental THeme Installation Error

### DIFF
--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -1956,8 +1956,9 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $b = parent::addBlock($bt, $a, $data);
         $btHandle = $bt->getBlockTypeHandle();
         $theme = $this->getCollectionThemeObject();
+        $area = is_object($a) ? $a : Area::getOrCreate($this, $a);
         if ($btHandle && $theme) {
-            $templates = array_merge($theme->getThemeDefaultBlockTemplates(), $a->getAreaCustomTemplates());
+            $templates = array_merge($theme->getThemeDefaultBlockTemplates(), $area->getAreaCustomTemplates());
             if (count($templates) && isset($templates[$btHandle])) {
                 $template = $templates[$btHandle];
                 $b->updateBlockInformation(array('bFilename' => $template));

--- a/web/concrete/themes/elemental/page_theme.php
+++ b/web/concrete/themes/elemental/page_theme.php
@@ -56,14 +56,14 @@ class PageTheme extends \Concrete\Core\Page\Theme\Theme {
         );
     }
 
+    /*
     public function getThemeDefaultBlockTemplates()
     {
-        /*
         return array(
             'image' => 'some_special_image_template'
         );
-        */
     }
+    */
 
     public function getThemeResponsiveImageMap()
     {


### PR DESCRIPTION
Check for Area handle and create object if needed. This is consistent
with the behavior of `Collection::addBlock()` as that can take both
`Area` object or handle.

Comment out theme method as the parent method always returns an empty
array not null