### PR TITLE
Fix Group::add() Exception

### DIFF
--- a/web/concrete/src/Tree/Node/Type/Group.php
+++ b/web/concrete/src/Tree/Node/Type/Group.php
@@ -99,7 +99,7 @@ class Group extends TreeNode
         }
     }
 
-    public function setTreeNodeGroup(UserGroup $g)
+    public function setTreeNodeGroup(\Concrete\Core\User\Group\Group $g)
     {
         $db = Loader::db();
         $db->Replace('TreeGroupNodes', array('treeNodeID' => $this->getTreeNodeID(), 'gID' => $g->getGroupID()), array('treeNodeID'), true);


### PR DESCRIPTION
Fix `Group::add()` Exception

`Argument 1 passed to
Concrete\Core\Tree\Node\Type\Group::setTreeNodeGroup() must be an
instance of Group, instance of Concrete\Core\User\Group\Group given,
called in /var/www/html/concrete/src/Tree/Node/Type/Group.php on line
114`

Type hint fails due to class alias

- Set to explicit namespace for `User\Group\Group` class in
  `Concrete\Core\Tree\Node\Type\Group::setTreeNodeGroup()`