### PR TITLE
Update for oauth 1 compatibility

### DIFF
--- a/web/concrete/src/Authentication/Type/OAuth/ServiceProvider.php
+++ b/web/concrete/src/Authentication/Type/OAuth/ServiceProvider.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Authentication\Type\OAuth;
 
+use Concrete\Core\Authentication\Type\OAuth\OAuth1a\GenericOauth1aTypeController;
 use Concrete\Core\Authentication\Type\OAuth\OAuth2\GenericOauth2TypeController;
 use Concrete\Core\Foundation\Service\Provider;
 use OAuth\Common\Http\Client\CurlClient;
@@ -42,7 +43,7 @@ class ServiceProvider extends Provider
                     if ($type && is_object($type) && !$type->isError()) {
                         /** @var GenericOauth2TypeController $controller */
                         $controller = $type->getController();
-                        if ($controller instanceof GenericOauth2TypeController) {
+                        if ($controller instanceof GenericOauth2TypeController || $controller instanceof GenericOauth1aTypeController) {
 
                             switch ($action) {
                                 case 'attempt_auth':


### PR DESCRIPTION
In testing the registration flow for Twitter, I found that this provider was expecting an oauth2 controller only. Added the functionality for checking for oauth1a controllers, too.