### PR TITLE
Remove Extra pkCategoryHandle from Select loadAll

### DIFF
--- a/web/concrete/src/Permission/Key/Key.php
+++ b/web/concrete/src/Permission/Key/Key.php
@@ -149,7 +149,7 @@ abstract class Key extends Object
         $db = Loader::db();
         $permissionkeys = array();
         $txt = Loader::helper('text');
-        $e = $db->Execute('select pkID, pkName, pkDescription, pkHandle, pkCategoryHandle, pkCanTriggerWorkflow, pkHasCustomClass, PermissionKeys.pkCategoryID, pkCategoryHandle, PermissionKeyCategories.pkgID from PermissionKeys inner join PermissionKeyCategories on PermissionKeyCategories.pkCategoryID = PermissionKeys.pkCategoryID');
+        $e = $db->Execute('select pkID, pkName, pkDescription, pkHandle, pkCategoryHandle, pkCanTriggerWorkflow, pkHasCustomClass, PermissionKeys.pkCategoryID, PermissionKeyCategories.pkgID from PermissionKeys inner join PermissionKeyCategories on PermissionKeyCategories.pkCategoryID = PermissionKeys.pkCategoryID');
         while ($r = $e->FetchRow()) {
             $class = '\\Core\\Permission\\Key\\' . $txt->camelcase($r['pkCategoryHandle']) . 'Key';
             if ($r['pkHasCustomClass']) {

--- a/web/concrete/src/Permission/Key/Key.php
+++ b/web/concrete/src/Permission/Key/Key.php
@@ -174,7 +174,7 @@ abstract class Key extends Object
     {
         $db = Loader::db();
         $txt = Loader::helper('text');
-        $r = $db->GetRow('select pkID, pkName, pkDescription, pkHandle, pkCategoryHandle, pkCanTriggerWorkflow, pkHasCustomClass, PermissionKeys.pkCategoryID, pkCategoryHandle, PermissionKeyCategories.pkgID from PermissionKeys inner join PermissionKeyCategories on PermissionKeyCategories.pkCategoryID = PermissionKeys.pkCategoryID where ' . $loadBy . ' = ?',
+        $r = $db->GetRow('select pkID, pkName, pkDescription, pkHandle, pkCategoryHandle, pkCanTriggerWorkflow, pkHasCustomClass, PermissionKeys.pkCategoryID, PermissionKeyCategories.pkgID from PermissionKeys inner join PermissionKeyCategories on PermissionKeyCategories.pkCategoryID = PermissionKeys.pkCategoryID where ' . $loadBy . ' = ?',
             array($key));
         $class = '\\Core\\Permission\\Key\\' . $txt->camelcase($r['pkCategoryHandle']) . 'Key';
         if (!is_array($r) && (!$r['pkID'])) {


### PR DESCRIPTION
Remove extra `pkCategoryHandle` from select statment in `Key::loadAll()`