### PR TITLE
Fix autoloader attributes

### DIFF
--- a/tests/tests/Core/Foundation/ClassloaderTest.php
+++ b/tests/tests/Core/Foundation/ClassloaderTest.php
@@ -107,6 +107,11 @@ class ClassloaderTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue(class_exists('\Concrete\Attribute\Boolean\Controller'));
 	}
 
+	public function testMultipleAttributeClassesInSameFile() {
+		$this->assertTrue(class_exists('\Concrete\Attribute\Select\Option', true));
+		$this->assertTrue(class_exists('\Concrete\Attribute\Address\Value', true));
+	}
+
 	public function testBlocks() {
 		$bt = new \BlockType();
 		$bt->setBlockTypeHandle('core_stack_display');

--- a/web/concrete/src/Foundation/ClassLoader.php
+++ b/web/concrete/src/Foundation/ClassLoader.php
@@ -28,7 +28,9 @@ class ClassLoader  {
 		$mapping = array(
 		    'Loader' => DIR_BASE_CORE . '/' . DIRNAME_CLASSES . '/Legacy/Loader.php',
 		    'TaskPermission' => DIR_BASE_CORE . '/' . DIRNAME_CLASSES . '/Legacy/TaskPermission.php',
-		    'FilePermissions' => DIR_BASE_CORE . '/' . DIRNAME_CLASSES . '/Legacy/FilePermissions.php'
+		    'FilePermissions' => DIR_BASE_CORE . '/' . DIRNAME_CLASSES . '/Legacy/FilePermissions.php',
+		    NAMESPACE_SEGMENT_VENDOR . '\\Attribute\\Select\\Option' => DIR_BASE_CORE . '/' . DIRNAME_ATTRIBUTES . '/select/controller.php',
+		    NAMESPACE_SEGMENT_VENDOR . '\\Attribute\\Address\\Value' => DIR_BASE_CORE . '/' . DIRNAME_ATTRIBUTES . '/address/controller.php',
 		);
 
 		$loader = new SymfonyMapClassloader($mapping);


### PR DESCRIPTION
Fix autoload for attributes that have additional classes defined in the
attribute `controller.php` file.

- Add class map for select `Option` class
- Add class map for address `Value` class

Note: This does not address autoloading in the /application directory