### PR TITLE
Adds Exclusion of Support directory from Doctrine ORM AnnotationDriver

### DIFF
--- a/web/concrete/config/database.php
+++ b/web/concrete/config/database.php
@@ -11,6 +11,13 @@ return array(
     'proxy_classes' => DIR_APPLICATION . '/config/doctrine/proxies',
 
     /**
+     * Paths to exclude from the doctrine proxy classes
+     */
+    'proxy_exclusions' => array(
+        DIR_BASE_CORE . '/' . DIRNAME_CLASSES . '/Support/',
+    ),
+
+    /**
      * The database charset
      */
     'charset' => 'utf8'

--- a/web/concrete/src/Database/DatabaseManagerORM.php
+++ b/web/concrete/src/Database/DatabaseManagerORM.php
@@ -107,6 +107,7 @@ class DatabaseManagerORM
         }
 
         $driverImpl = $config->newDefaultAnnotationDriver($path);
+        $driverImpl->addExcludePaths(Config::get('database.proxy_exclusions', array()));
         $config->setMetadataDriverImpl($driverImpl);
 
         $event = new \Symfony\Component\EventDispatcher\GenericEvent();


### PR DESCRIPTION
Adds exclusion of the core support directory from the Doctrine ORM annotation driver

Fixes #1975 and adds support for adding other exclusions as seen fit.

