### PR TITLE
Login forwarding for protected pages

### DIFF
--- a/web/concrete/src/Routing/DispatcherRouteCallback.php
+++ b/web/concrete/src/Routing/DispatcherRouteCallback.php
@@ -13,6 +13,7 @@ use View;
 use Permissions;
 use Response;
 use Core;
+use Session;
 
 class DispatcherRouteCallback extends RouteCallback
 {

--- a/web/concrete/src/Routing/DispatcherRouteCallback.php
+++ b/web/concrete/src/Routing/DispatcherRouteCallback.php
@@ -47,6 +47,12 @@ class DispatcherRouteCallback extends RouteCallback
 
     protected function sendPageForbidden(Request $request)
     {
+        // set page for redirection after successful login
+        $currentPage = Page::getByPath($request->getPath());
+        if($currentPage){
+                Session::set('rcID', $currentPage->getCollectionID());
+        }
+        // load page forbidden
         $item = '/page_forbidden';
         $c = Page::getByPath($item);
         if (is_object($c) && !$c->isError()) {


### PR DESCRIPTION
Adds a forbidden page's cID to Session as 'rcID' to allow login controller to automatically forward to the page after a successful login. This functionality was available pre-5.7.