### PR TITLE
autocomplete=off for passwords

### DIFF
--- a/web/concrete/authentication/concrete/change_password.php
+++ b/web/concrete/authentication/concrete/change_password.php
@@ -18,11 +18,11 @@ $form = Loader::helper('form');
         $uHash) ?>">
         <div class="form-group">
             <label class="control-label" for="uPassword"><?= t('New Password') ?></label>
-            <input type="password" name="uPassword" id="uPassword" class="form-control"/>
+            <input type="password" name="uPassword" id="uPassword" class="form-control" autocomplete="off"/>
         </div>
         <div class="form-group">
             <label class="control-label" for="uPassword"><?= t('Confirm New Password') ?></label>
-            <input type="password" name="uPasswordConfirm" id="uPasswordConfirm" class="form-control"/>
+            <input type="password" name="uPasswordConfirm" id="uPasswordConfirm" class="form-control" autocomplete="off"/>
         </div>
         <div class="form-group">
             <button class="btn btn-primary"><?= t('Change password and sign in') ?></button>

--- a/web/concrete/authentication/concrete/form.php
+++ b/web/concrete/authentication/concrete/form.php
@@ -16,7 +16,7 @@ $form = Loader::helper('form');
     <div class="form-group">
         <label>&nbsp;</label>
         <input name="uPassword" class="form-control" type="password"
-               placeholder="<?=t('Password')?>" />
+               placeholder="<?=t('Password')?>" autocomplete="off" />
     </div>
 
     <div class="checkbox">

--- a/web/concrete/single_pages/dashboard/system/mail/method.php
+++ b/web/concrete/single_pages/dashboard/system/mail/method.php
@@ -32,7 +32,7 @@ $form = Loader::helper('form');
                     </div>
                     <div class="form-group">
                         <?=$form->label('MAIL_SEND_METHOD_SMTP_PASSWORD',t('Password'));?>
-                        <?=$form->password('MAIL_SEND_METHOD_SMTP_PASSWORD', Config::get('concrete.mail.methods.smtp.password'), array('autocomplete' => 'off'))?>
+                        <?=$form->password('MAIL_SEND_METHOD_SMTP_PASSWORD', Config::get('concrete.mail.methods.smtp.password'))?>
                     </div>
 
                     <div class="form-group">

--- a/web/concrete/single_pages/download_file.php
+++ b/web/concrete/single_pages/download_file.php
@@ -23,7 +23,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			<input type="hidden" value="<?= $force ?>" name="force" />
 		<? } ?>
 		<input type="hidden" value="<?= $rcID ?>" name="rcID"/>
-		<label for="password"><?=t('Password')?>: <input type="password" name="password" /></label>
+		<label for="password"><?=t('Password')?>: <input type="password" name="password" autocomplete="off"/></label>
 		<br /><br />
 		<button type="submit"><?=t('Download')?></button>
 	</form>

--- a/web/concrete/src/Form/Service/Form.php
+++ b/web/concrete/src/Form/Service/Form.php
@@ -387,7 +387,7 @@ class Form {
 	 * @return $html
 	 */
 	public function password($key, $valueOrArray = false, $miscFields = array()) {
-		return $this->inputType($key, 'password', $valueOrArray, $miscFields);
+		return $this->inputType($key, 'password', $valueOrArray, array_merge(array('autocomplete' => 'off'), $miscFields));
 	}
 
 	/**


### PR DESCRIPTION
This should fix up #2006. It's actually probably far more broad than just that since I'm forcing autocomplete="off" for anything that uses the form helper password method. Not sure if this is desired by all but it seemed like a legitimate thing to do to me. If someone really wanted to circumvent it they can just do an array('autocomplete' => 'on) for the misc options and it should override that setting so I didn't feel like I left those who don't want the behavior without an option on this one.