### PR TITLE
Make firefox empty area borders size appropriately

### DIFF
--- a/web/concrete/css/build/core/app/page-areas.less
+++ b/web/concrete/css/build/core/app/page-areas.less
@@ -176,7 +176,7 @@ div.ccm-menu-item-hover {
 /**
  * Empty areas
  */
-div.ccm-area[data-total-blocks="0"] {
+div.ccm-area[data-total-blocks="0"] div.ccm-area-block-list {
 
   outline: 1px solid #e6e6e6;
   outline-offset: -1px;

--- a/web/concrete/css/build/core/app/page-areas.less
+++ b/web/concrete/css/build/core/app/page-areas.less
@@ -187,6 +187,7 @@ div.ccm-area[data-total-blocks="0"] div.ccm-area-block-list {
 div.ccm-area[data-total-blocks="0"].ccm-area-drag-block-type-over, div.ccm-area[data-total-blocks="0"].ccm-menu-item-hover {
 
   outline: 1px solid #0c6;
+  outline-offset: 0;
 
   div.ccm-area-footer-handle {
     border-color: #0c6;


### PR DESCRIPTION
This pull takes firefox from looking like:
![capture1](https://cloud.githubusercontent.com/assets/1292766/6351301/6413d7ce-bc08-11e4-8161-b554fb39314b.PNG)

To more like one would expect:
![capture2](https://cloud.githubusercontent.com/assets/1292766/6351307/6bad1e8c-bc08-11e4-96ed-063d09eb2d36.PNG)
