### PR TITLE
Better translator interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ __IDE_SYMBOLS__.php
 /web/concrete/js/lightbox.js
 /web/concrete/js/legacy.js
 /web/concrete/js/select2.js
+/web/concrete/js/translator.js
 
 # CSS
 /web/concrete/css/select2.css
@@ -124,3 +125,4 @@ __IDE_SYMBOLS__.php
 /web/concrete/themes/dashboard/main.css
 /web/concrete/themes/elemental/css/bootstrap-modified.css
 /web/concrete/css/legacy.css
+/web/concrete/css/translator.css

--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -309,6 +309,10 @@ module.exports = function(grunt) {
                 '<%= DIR_BASE %>/concrete/js/build/vendor/jquery-placeholder/jquery.placeholder.js',
                 '<%= DIR_BASE %>/concrete/js/build/core/legacy.js'
             ]
+        },
+		  ccm_translator: {
+            dest: '<%= DIR_BASE %>/concrete/js/translator.js',
+            src: '<%= DIR_BASE %>/concrete/js/build/core/translator.js'
         }
     };
 
@@ -349,7 +353,8 @@ module.exports = function(grunt) {
         '<%= DIR_BASE %>/concrete/css/topics.css': '<%= DIR_BASE %>/concrete/css/build/core/topics.less',
         '<%= DIR_BASE %>/concrete/themes/elemental/css/bootstrap-modified.css': '<%= DIR_BASE %>/concrete/themes/elemental/css/build/bootstrap-3.2.0/bootstrap.less',
         '<%= DIR_BASE %>/concrete/css/frontend/pagination.css': '<%= DIR_BASE %>/concrete/css/build/core/frontend/pagination.less',
-        '<%= DIR_BASE %>/concrete/css/legacy.css': '<%= DIR_BASE %>/concrete/css/build/core/legacy.less'
+        '<%= DIR_BASE %>/concrete/css/legacy.css': '<%= DIR_BASE %>/concrete/css/build/core/legacy.less',
+		  '<%= DIR_BASE %>/concrete/css/translator.css': '<%= DIR_BASE %>/concrete/css/build/core/translator.less'
     };
 
     // Let's include the dependencies

--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -310,7 +310,7 @@ module.exports = function(grunt) {
                 '<%= DIR_BASE %>/concrete/js/build/core/legacy.js'
             ]
         },
-		  ccm_translator: {
+        ccm_translator: {
             dest: '<%= DIR_BASE %>/concrete/js/translator.js',
             src: '<%= DIR_BASE %>/concrete/js/build/core/translator.js'
         }
@@ -354,7 +354,7 @@ module.exports = function(grunt) {
         '<%= DIR_BASE %>/concrete/themes/elemental/css/bootstrap-modified.css': '<%= DIR_BASE %>/concrete/themes/elemental/css/build/bootstrap-3.2.0/bootstrap.less',
         '<%= DIR_BASE %>/concrete/css/frontend/pagination.css': '<%= DIR_BASE %>/concrete/css/build/core/frontend/pagination.less',
         '<%= DIR_BASE %>/concrete/css/legacy.css': '<%= DIR_BASE %>/concrete/css/build/core/legacy.less',
-		  '<%= DIR_BASE %>/concrete/css/translator.css': '<%= DIR_BASE %>/concrete/css/build/core/translator.less'
+        '<%= DIR_BASE %>/concrete/css/translator.css': '<%= DIR_BASE %>/concrete/css/build/core/translator.less'
     };
 
     // Let's include the dependencies

--- a/web/concrete/config/app.php
+++ b/web/concrete/config/app.php
@@ -665,6 +665,10 @@ return array(
         'core/legacy'              => array(
             array('javascript', 'js/legacy.js'),
             array('css', 'css/legacy.css')
+        ),
+        'core/translator' => array(
+            array('javascript', 'js/translator.js', array('minify' => false)),
+            array('css', 'css/translator.css', array('minify' => false))
         )
     ),
     'asset_groups'        => array(
@@ -923,6 +927,12 @@ return array(
                 array('javascript', 'jquery'),
                 array('javascript', 'core/legacy'),
                 array('css', 'core/legacy')
+            )
+        ),
+        'core/translator'          => array(
+            array(
+                array('javascript', 'core/translator'),
+                array('css', 'core/translator'),
             )
         )
     )

--- a/web/concrete/controllers/single_page/dashboard/system/multilingual/translate_interface.php
+++ b/web/concrete/controllers/single_page/dashboard/system/multilingual/translate_interface.php
@@ -184,10 +184,7 @@ class TranslateInterface extends DashboardPageController
                     $jsonTranslation['comments'] = $extractedComments;
                 }
                 if ($translation->hasReferences()) {
-                    $jsonTranslation['references'] = array();
-                    foreach ($translation->getReferences() as $ref) {
-                        $jsonTranslation['references'][] = isset($ref[1]) ? "{$ref[0]}:{$ref[1]}" : $ref[0];
-                    }
+                    $jsonTranslation['references'] = $translation->getReferences();
                 }
                 $jsonTranslations[] = $jsonTranslation;
             }

--- a/web/concrete/controllers/single_page/dashboard/system/multilingual/translate_interface.php
+++ b/web/concrete/controllers/single_page/dashboard/system/multilingual/translate_interface.php
@@ -114,13 +114,38 @@ class TranslateInterface extends DashboardPageController
 
     public function save_translation()
     {
-        $mtID = intval($this->post('mtID'));
-        $translation = Translation::getByRecordID($mtID);
-        if (is_object($translation)) {
-            $translation->updateTranslation($this->post('msgstr'));
+        $result = new EditResponse();
+        try {
+            $translation = null;
+            $mtID = @intval($this->post('id'));
+            if ($mtID > 0) {
+                $translation = Translation::getByRecordID($mtID);
+            }
+            if (!isset($translation)) {
+                throw new \Exception(t('Invalid parameter received: %s', 'id'));
+            }
+            $singular = '';
+            $plurals = array();
+            if ($this->post('clear') !== '1') {
+                $translated = $this->post('translated');
+                if ((!is_array($translated)) || (count($translated) < 1)) {
+                    throw new \Exception(t('Invalid parameter received: %s', 'translated'));
+                }
+                if ($translation->hasPlural()) {
+                    $singular = array_shift($translated);
+                    $plurals = $translated;
+                } else {
+                    if (count($translated) !== 1) {
+                        throw new \Exception(t('Invalid parameter received: %s', 'translated'));
+                    }
+                    $singular = $translated[0];
+                }
+            }
+            $translation->updateTranslation($singular, $plurals);
+        } catch (\Exception $x) {
+            $result->setError($x);
         }
-        $r = new EditResponse();
-        $r->outputJSON();
+        $result->outputJSON();
     }
 
     public function translate_po($mtSectionID = false)
@@ -128,9 +153,50 @@ class TranslateInterface extends DashboardPageController
         $mtSectionID = intval($mtSectionID);
         $section = Section::getByID(intval($mtSectionID));
         if ($section) {
-            $translations = $section->getSectionInterfaceTranslations(true);
+            $translations = $section->getSectionInterfaceTranslations();
+            $this->requireAsset('core/translator');
             $this->set('section', $section);
-            $this->set('translations', $translations);
+            $jsonTranslations = array();
+            $numPlurals = $section->getNumberOfPluralForms();
+            foreach ($translations as $translation) {
+                /* @var $translation \Concrete\Core\Multilingual\Page\Section\Translation */
+                $jsonTranslation = array();
+                $jsonTranslation['id'] = $translation->getRecordID();
+                if ($translation->hasContext()) {
+                    $jsonTranslation['context'] = $translation->getContext();
+                }
+                $jsonTranslation['original'] = $translation->getOriginal();
+                if ($translation->hasPlural()) {
+                    $jsonTranslation['originalPlural'] = $translation->getPlural();
+                }
+                if ($translation->hasTranslation()) {
+                    $t = array($translation->getTranslation());
+                    if (($numPlurals > 1) && $translation->hasPlural()) {
+                        $t = array_merge($t, $translation->getPluralTranslation());
+                    }
+                    $jsonTranslation['translations'] = $t;
+                }
+                $extractedComments = '';
+                if ($translation->hasExtractedComments()) {
+                    $extractedComments = trim(implode("\n", $translation->getExtractedComments()));
+                }
+                if ($extractedComments !== '') {
+                    $jsonTranslation['comments'] = $extractedComments;
+                }
+                if ($translation->hasReferences()) {
+                    $jsonTranslation['references'] = array();
+                    foreach ($translation->getReferences() as $ref) {
+                        $jsonTranslation['references'][] = isset($ref[1]) ? "{$ref[0]}:{$ref[1]}" : $ref[0];
+                    }
+                }
+                $jsonTranslations[] = $jsonTranslation;
+            }
+            $jsonOptions = 0;
+            if (defined('\JSON_UNESCAPED_SLASHES')) {
+                $jsonOptions |= \JSON_UNESCAPED_SLASHES;
+            }
+            $this->set('jsonOptions', $jsonOptions);
+            $this->set('translations', $jsonTranslations);
         } else {
             $this->redirect('/dashboard/system/multilingual/translate_interface');
         }

--- a/web/concrete/css/build/core/translator.less
+++ b/web/concrete/css/build/core/translator.less
@@ -1,0 +1,32 @@
+.ccm-translator {
+	.ccm-translator-col-original {
+		.panel-heading span {
+			float: left;
+			width: 50%;
+			height: 20px;
+			overflow: hidden;
+		}
+		ul {
+			overflow: scroll;
+			overflow-x: hidden;
+		}
+		li {
+			transition: all 0.2s linear;
+	   	cursor: pointer;
+	   	&:hover {
+				background-color: #dedede;
+			}
+			span {
+				float: left;
+				width: 50%;
+				height: 20px;
+				overflow: hidden;
+			}
+		}
+	}
+	.ccm-translator-col-translations {
+		> .panel {
+			visibility: hidden;
+		}
+	}
+}

--- a/web/concrete/js/build/core/translator.js
+++ b/web/concrete/js/build/core/translator.js
@@ -52,8 +52,6 @@ var frontend = {
   colTranslations: 'col-md-7'
 };
 
-var translatorsCount = 0;
-
 function Translation(data, translator) {
   $.extend(this, data);
   this.hasContext = 'context' in data;
@@ -151,7 +149,6 @@ var TranslationView = (function() {
     this.translation = translation;
     this.multiline = multiline;
     this.element = this.multiline ? 'textarea rows="8"' : 'input type="text"';
-    this.uniquePrefix = 'ccm-translator' + this.translation.translator.index + '-translation';
     this.readOnly = false;
     if (this.translation.translator.approvalSupport && this.translation.isApproved && (!this.translation.translator.canModifyApproved)) {
       this.readOnly = true;
@@ -356,11 +353,11 @@ var TranslationView = (function() {
           firstKey = key;
         }
         my.UI.$tabHeaders.append($('<li data-key="' + key + '"' + ((index === 0) ? ' class="active"' : '') + ' />')
-          .append($('<a href="#' + my.uniquePrefix + '-' + key + '" />')
+          .append($('<a href="#" />')
             .text(i18n.PluralNames[key])
           )
         );
-        my.UI.$tabBodies.append($('<div id="' + my.uniquePrefix + '-' + key + '" class="tab-pane' + ((index === 0) ? ' active' : '') + '"  data-key="' + key + '" />')
+        my.UI.$tabBodies.append($('<div class="tab-pane' + ((index === 0) ? ' active' : '') + '"  data-key="' + key + '" />')
           .append($('<p />').text(i18n.ExamplePH.replace(/%s/, examples)))
           .append(my.UI.$translated[key] = $('<' + my.element + (my.readOnly ? ' readonly="readonly"' : '') + ' class="form-control" />').val(my.translation.isTranslated ? my.translation.translations[index] : ''))
         );
@@ -406,7 +403,6 @@ var TranslationView = (function() {
 })();
 
 function Translator(data) {
-  this.index = translatorsCount++;
   this.containerID = data.container;
   this.height = data.height;
   this.saveAction = data.saveAction;
@@ -620,7 +616,9 @@ Translator.prototype = {
       switch (e.keyCode || e.which) {
         case 9:
           e.preventDefault();
-          my.saveAndContinue(e.shiftKey ? true : false);
+          setTimeout(function() {
+            my.saveAndContinue(e.shiftKey ? true : false);
+          }, 0);
           break;
       }
     });

--- a/web/concrete/js/build/core/translator.js
+++ b/web/concrete/js/build/core/translator.js
@@ -2,7 +2,7 @@
 (function() {
 'use strict';
 
-if(window.ccmTranslator) {
+if (window.ccmTranslator) {
   return;
 }
 
@@ -84,8 +84,8 @@ Translation.prototype = {
   },
   translationUpdated: function(skipSetClass) {
     this.liTranslated.textContent = this.liTranslated.innerText = (this.isTranslated ? this.translations[0] : '');
-    if(skipSetClass !== true) {
-      if(this.isTranslated) {
+    if (skipSetClass !== true) {
+      if (this.isTranslated) {
         $(this.li).addClass('list-group-item-success');
       } else {
         $(this.li).removeClass('list-group-item-success');
@@ -93,10 +93,10 @@ Translation.prototype = {
     }
   },
   translatedSaved: function(translations, approved) {
-    if(translations === null) {
+    if (translations === null) {
       delete this.translations;
       this.isTranslated = false;
-      if(this.translator.approvalSupport) {
+      if (this.translator.approvalSupport) {
         this.isApproved = false;
       }
     } else {
@@ -130,12 +130,12 @@ Translation.prototype = {
     if ((filter.showUntranslated === false) && (this.isTranslated === false)) return false;
     if ((filter.showApproved === false) && (this.isApproved === true)) return false;
     if ((filter.showUnapproved === false) && (this.isApproved === false)) return false;
-    if(filter.text.length > 0) {
+    if (filter.text.length > 0) {
       var textFound = false;
       textFound = textFound || (filter.searchInContexts && this.contextContains(filter.lowerCaseText));
       textFound = textFound || (filter.searchInOriginals && this.originalContains(filter.lowerCaseText));
       textFound = textFound || (filter.searchInTranslations && this.translationContains(filter.lowerCaseText));
-      if(textFound === false) return false;
+      if (textFound === false) return false;
     }
     return true;
   },
@@ -153,7 +153,7 @@ var TranslationView = (function() {
     this.element = this.multiline ? 'textarea rows="8"' : 'input type="text"';
     this.uniquePrefix = 'ccm-translator' + this.translation.translator.index + '-translation';
     this.readOnly = false;
-    if(this.translation.translator.approvalSupport && this.translation.isApproved && (!this.translation.translator.canModifyApproved)) {
+    if (this.translation.translator.approvalSupport && this.translation.isApproved && (!this.translation.translator.canModifyApproved)) {
       this.readOnly = true;
     }
     this.UI.$container = this.translation.translator.UI.$translation;
@@ -161,8 +161,8 @@ var TranslationView = (function() {
     this.UI.$container.closest('.panel').css('visibility', 'visible');
     this.buildOriginalUI();
     this.buildTranslationUI();
-    if(this.translation.translator.approvalSupport) {
-      if(this.translation.translator.canModifyApproved) {
+    if (this.translation.translator.approvalSupport) {
+      if (this.translation.translator.canModifyApproved) {
         this.UI.$container
             .append($('<label class="control-label checkbox inline" />')
               .text(i18n.Approved)
@@ -173,7 +173,7 @@ var TranslationView = (function() {
         this.UI.$container.append($('<p />').text(this.translation.isApproved ? i18n.TranslationIsApproved_ReadOnly : i18n.TranslationIsNotApproved));
       }
     }
-    if(('comments' in this.translation) || ('context' in this.translation) || ('references' in this.translation)) {
+    if (('comments' in this.translation) || ('context' in this.translation) || ('references' in this.translation)) {
       var $dl;
       this.UI.$container.append($dl = $('<dl />'));
       if ('comments' in this.translation) {
@@ -189,11 +189,33 @@ var TranslationView = (function() {
         ;
       }
       if ('references' in this.translation) {
+        var referencePatterns = this.translation.translator.referencePatterns;
         var $dd;
         $dl
           .append($('<dt />').text(i18n.References))
-          .append($dd = $('<dd style="overflow: hidden; white-space: pre" />').text(this.translation.references.join('\n')))
+          .append($dd = $('<dd style="overflow: hidden; white-space: pre" />'))
         ;
+        $.each(this.translation.references, function(index, reference) {
+          if (index > 0) {
+            $dd.append('<br />');
+          }
+          var s, pattern;
+          if ((reference.length > 1) && (reference[1] !== null)) {
+            s = reference.join(':');
+            pattern = referencePatterns.file_line;
+          } else {
+            s = reference[0];
+            pattern = referencePatterns.file;
+          }
+          if(pattern) {
+            $dd.append($('<a target="_blank" />')
+              .text(s)
+              .attr('href', pattern.replace(/\[\[FILE\]\]/g, reference[0]).replace(/\[\[LINE\]\]/g, reference[1]))
+            );
+          } else {
+            $dd.append($('<span />').text(s));
+          }
+        });
         $dd.attr('title', $dd.text());
       }
     }
@@ -203,17 +225,17 @@ var TranslationView = (function() {
     var $ul = $li.closest('ul');
     var liTop = $li.position().top - $ul.position().top;
     var ulTop = $ul.scrollTop();
-    if(liTop < 0) {
+    if (liTop < 0) {
       newScrollTop = ulTop + liTop;
     }
     else {
       var liBottom = liTop + $li.outerHeight();
       var ulBottom = $ul.height();
-      if(liBottom > ulBottom) {
+      if (liBottom > ulBottom) {
         newScrollTop = ulTop + (liBottom - ulBottom);
       }
     }
-    if(newScrollTop !== null) {
+    if (newScrollTop !== null) {
       $ul.animate({scrollTop: newScrollTop}, 50);
     }
   }
@@ -229,27 +251,27 @@ var TranslationView = (function() {
         return strings;
       }
       var result = {strings: strings};
-      if('$approved' in this.UI) {
+      if ('$approved' in this.UI) {
         result.approved = this.UI.$approved.is(':checked') ? true : false;
       }
       return result;
     },
     isDirty: function() {
       var translatedState = this.getTranslatedState();
-      if(translatedState === null) {
+      if (translatedState === null) {
         return this.translation.isTranslated ? true : false;
       }
       if (this.translation.isTranslated === false) {
         return true;
       }
       var dirty = false;
-      for(var n = translatedState.strings.length, i = 0; i < n; i++) {
-        if(translatedState.strings[i] !== this.translation.translations[i]) {
+      for (var n = translatedState.strings.length, i = 0; i < n; i++) {
+        if (translatedState.strings[i] !== this.translation.translations[i]) {
           dirty = true;
           break;
         }
       }
-      if(('approved' in translatedState) && (translatedState.approved !== this.translation.isApproved)) {
+      if (('approved' in translatedState) && (translatedState.approved !== this.translation.isApproved)) {
         dirty = true;
       }
       return dirty;
@@ -313,7 +335,7 @@ var TranslationView = (function() {
       this.UI.$tabBodies.find('.tab-pane.active').removeClass('active');
       this.UI.$tabHeaders.find('li[data-key="' + key + '"]').addClass('active');
       var $pane = this.UI.$tabBodies.find('.tab-pane[data-key="' + key + '"]').addClass('active');
-      if(focalize) {
+      if (focalize) {
         $pane.find('textarea,input').focus();
       }
     },
@@ -363,7 +385,7 @@ var TranslationView = (function() {
         var s = $.trim(my.UI.$translated[key].val());
         if (s.length > 0) {
           some = true;
-        } else if(firstNotFilled === null) {
+        } else if (firstNotFilled === null) {
           firstNotFilled = key;
         }
         result.push(s);
@@ -391,6 +413,7 @@ function Translator(data) {
   this.plurals = $.extend(true, {}, data.plurals);
   this.translations = [];
   this.approvalSupport = (data.approvalSupport === false) ? false : true;
+  this.referencePatterns = $.extend(true, {file: null, file_line: null}, data.referencePatterns);
   if (this.approvalSupport) {
     this.canModifyApproved = (data.canModifyApproved === true) ? true : false;
   }
@@ -407,7 +430,7 @@ Translator.prototype = {
     delete this.containerID;
     var height = this.height;
     delete this.height;
-    if((!height) || (height < 200)) {
+    if ((!height) || (height < 200)) {
       height = 200;
     }
     this.UI.$container
@@ -510,7 +533,7 @@ Translator.prototype = {
       )
     ;
     var n = this.translations.length;
-    if(n < MAX_TRANSLATIONS_FOR_FASTSEARCH) {
+    if (n < MAX_TRANSLATIONS_FOR_FASTSEARCH) {
       this.UI.$searchButton.remove();
       var hAutosearchTimer = null;
       this.UI.$searchText.on('change keydown keyup keypress', function() {
@@ -533,7 +556,7 @@ Translator.prototype = {
       });
     }
     var someContexts = false;
-    for(var i = 0; i < n; i++) {
+    for (var i = 0; i < n; i++) {
       this.translations[i].buildListItem();
       if (this.translations[i].hasContext) {
         someContexts = true;
@@ -561,7 +584,7 @@ Translator.prototype = {
     this.UI.$showUntranslated.on('click', function() {
       my.filter({showUntranslated: !my.appliedFilter.showUntranslated});
     });
-    if(this.approvalSupport) {
+    if (this.approvalSupport) {
       this.UI.$showUnapproved.on('click', function() {
         my.filter({showUnapproved: !my.appliedFilter.showUnapproved});
       });
@@ -577,7 +600,7 @@ Translator.prototype = {
       delete this.UI.$showUnapproved;
       delete this.UI.$showApproved;
     }
-    if(someContexts) {
+    if (someContexts) {
       this.UI.$searchInContexts.on('click', function() {
         my.filter({searchInContexts: !my.appliedFilter.searchInContexts});
       });
@@ -586,11 +609,11 @@ Translator.prototype = {
     }
     this.viewAppliedFilter();
     $(window).on('beforeunload', function() {
-      if(my.currentTranslationView && my.currentTranslationView.isDirty()) {
+      if (my.currentTranslationView && my.currentTranslationView.isDirty()) {
         return i18n.AskDiscardDirtyTranslation;
       }
     });
-    if(n > 0) {
+    if (n > 0) {
       this.setCurrentTranslation(this.translations[0]);
     }
     this.UI.$container.on('keydown', function(e) {
@@ -604,13 +627,13 @@ Translator.prototype = {
   },
   viewAppliedFilter: function() {
     var f = this.appliedFilter;
-    if(this.UI.$searchText.text() !== f.text) {
+    if (this.UI.$searchText.text() !== f.text) {
       this.UI.$searchText.text(f.text); 
     }
     this.UI.$searchInOriginals.find('i').removeClass('fa-check-square-o fa-square-o').addClass(f.searchInOriginals ? 'fa-check-square-o' : 'fa-square-o');
     this.UI.$searchInTranslations.find('i').removeClass('fa-check-square-o fa-square-o').addClass(f.searchInTranslations ? 'fa-check-square-o' : 'fa-square-o');
     this.UI.$searchInContexts.find('i').removeClass('fa-check-square-o fa-square-o').addClass(f.searchInContexts ? 'fa-check-square-o' : 'fa-square-o');
-    if(this.approvalSupport) {
+    if (this.approvalSupport) {
       this.UI.$showUnapproved.find('i').removeClass('fa-check-square-o fa-square-o').addClass(f.showUnapproved ? 'fa-check-square-o' : 'fa-square-o');
       this.UI.$showApproved.find('i').removeClass('fa-check-square-o fa-square-o').addClass(f.showApproved ? 'fa-check-square-o' : 'fa-square-o');
     }
@@ -622,14 +645,14 @@ Translator.prototype = {
     var newFilter = $.extend(true, {}, this.appliedFilter, f, {text: this.UI.$searchText.val()});
     var needApplyFilter = false;
     $.each(newFilter, function(key, value) {
-      if(value === my.appliedFilter[key]) {
+      if (value === my.appliedFilter[key]) {
         return;
       }
       switch(key) {
         case 'searchInOriginals':
         case 'searchInTranslations':
         case 'searchInContexts':
-          if(my.appliedFilter.text === '') {
+          if (my.appliedFilter.text === '') {
             return;
           }
           break;
@@ -639,12 +662,12 @@ Translator.prototype = {
     });
     this.appliedFilter = newFilter;
     this.viewAppliedFilter();
-    if(!needApplyFilter) {
+    if (!needApplyFilter) {
       return;
     }
     this.appliedFilter.lowerCaseText = this.appliedFilter.text.toLowerCase();
     var n = this.translations.length;
-    for(var i = 0; i < n; i++) {
+    for (var i = 0; i < n; i++) {
       this.translations[i].applyFilter();
     }
   },
@@ -652,19 +675,19 @@ Translator.prototype = {
     if (this.saving) {
       return false;
     }
-    if(this.currentTranslationView) {
-      if(this.currentTranslationView.translation === translation) {
+    if (this.currentTranslationView) {
+      if (this.currentTranslationView.translation === translation) {
         return;
       }
-      if(this.currentTranslationView.isDirty()) {
-        if(!window.confirm(i18n.AskDiscardDirtyTranslation)) {
+      if (this.currentTranslationView.isDirty()) {
+        if (!window.confirm(i18n.AskDiscardDirtyTranslation)) {
           return;
         }
       }
       this.currentTranslationView.dispose();
       this.currentTranslationView = null;
     }
-    if(translation === null) {
+    if (translation === null) {
       return;
     }
     this.currentTranslationView = translation.isPlural ? new TranslationView.Plural(translation) :  new TranslationView.Singular(translation);
@@ -672,7 +695,7 @@ Translator.prototype = {
   setSaving: function(saving) {
     this.saving = !!saving;
     var $btn = this.UI.$container.find('button.ccm-translator-savecontinue');
-    if(this.saving) {
+    if (this.saving) {
       $btn.css('width', $btn.outerWidth() + 'px').html('<span class="fa fa-spinner fa-spin"></span>');
     } else {
       $btn.css('width', 'auto').text(i18n.Save_and_Continue);
@@ -683,7 +706,7 @@ Translator.prototype = {
     if (this.saving) {
       return;
     }
-    if(this.currentTranslationView.isDirty() === false) {
+    if (this.currentTranslationView.isDirty() === false) {
       this.gotoNextTranslation(backward);
       return;
     }
@@ -694,7 +717,7 @@ Translator.prototype = {
     var translation = this.currentTranslationView.translation;
     var postData = {};
     postData.id = translation.id;
-    if(translatedState === null) {
+    if (translatedState === null) {
       postData.clear = 1;
     } else {
       postData.translated = translatedState.strings;
@@ -720,7 +743,7 @@ Translator.prototype = {
       }
     })
     .done(function(response) {
-      if(response && response.error) {
+      if (response && response.error) {
         window.alert(response.errors.join("\n"));
         return;
       }
@@ -730,7 +753,7 @@ Translator.prototype = {
   },
   gotoNextTranslation: function(backward) {
     var $lis = this.UI.$list.children(':visible');
-    if($lis.length === 0) {
+    if ($lis.length === 0) {
       this.setCurrentTranslation(null);
       return;
     }
@@ -764,13 +787,13 @@ var Startup = (function() {
   return {
     setDomReady: function() {
       domReady = true;
-      if(readyTranslators.length) {
+      if (readyTranslators.length) {
         launch();
       }
     },
     setTranslatorReady: function(translator) {
       readyTranslators.push(translator);
-      if(domReady) {
+      if (domReady) {
         launch();
       }
     }
@@ -782,7 +805,7 @@ window.ccmTranslator = {
     $.extend(true, i18n, i18nDictionary);
   },
   configureFrontend: function(frontendConfig) {
-    if($.isPlainObject(frontendConfig)) {
+    if ($.isPlainObject(frontendConfig)) {
       $.extend(frontend, frontendConfig);
     }
   },

--- a/web/concrete/js/build/core/translator.js
+++ b/web/concrete/js/build/core/translator.js
@@ -60,7 +60,7 @@ Translation.prototype = {
     this.li.ccmTranslation = this;
     this.li.className = 'list-group-item clearfix' + (this.isTranslated ? ' list-group-item-success' : '');
     var sub = document.createElement('span');
-    sub.textContent = sub.textText = this.original;
+    sub.textContent = sub.innerText = this.original;
     this.li.appendChild(sub);
     this.liTranslated = document.createElement('span');
     this.translationUpdated(true);
@@ -71,7 +71,7 @@ Translation.prototype = {
     };
   },
   translationUpdated: function(skipSetClass) {
-    this.liTranslated.textContent = this.liTranslated.textText = (this.isTranslated ? this.translations[0] : '');
+    this.liTranslated.textContent = this.liTranslated.innerText = (this.isTranslated ? this.translations[0] : '');
     if(skipSetClass !== true) {
       if(this.isTranslated) {
         $(this.li).addClass('list-group-item-success');

--- a/web/concrete/js/build/core/translator.js
+++ b/web/concrete/js/build/core/translator.js
@@ -1,0 +1,720 @@
+/* jshint unused:vars, undef:true, browser:true, jquery:true */
+(function() {
+'use strict';
+
+if(window.ccmTranslator) {
+  return;
+}
+
+var MAX_TRANSLATIONS_FOR_FASTSEARCH = 500;
+
+var i18n = {
+  AskDiscardDirtyTranslation: 'The current item has changed.\nIf you proceed you will lose your changes.\n\nDo you want to proceed anyway?',
+  Comments: 'Comments',
+  Context: 'Context',
+  ExamplePH: 'Example: %s',
+  Filter: 'Filter',
+  Original_String: 'Original String',
+  Please_fill_in_all_plurals: 'Please fill-in all plural forms',
+  Plural_Original_String: 'Plural Original String',
+  References: 'References',
+  Save_and_Continue: 'Save & Continue',
+  Search_for_: 'Search for...',
+  Search_in_contexts: 'Search in contexts',
+  Search_in_originals: 'Search in originals',
+  Search_in_translations: 'Search in translations',
+  Show_approved: 'Show approved',
+  Show_translated: 'Show translated',
+  Show_unapproved: 'Show unapproved',
+  Show_untranslated: 'Show untranslated',
+  Singular_Original_String: 'Singular Original String',
+  Toggle_Dropdown: 'Toggle Dropdown',
+  TAB: '[TAB] Forward',
+  TAB_SHIFT: '[SHIFT]+[TAB] Backward',
+  Translate: 'Translate',
+  Translation: 'Translation',
+  PluralNames: {
+    zero: 'Zero',
+    one: 'One',
+    two: 'Two',
+    few: 'Few',
+    many: 'Many',
+    other: 'Other'
+  }
+};
+
+var translatorsCount = 0;
+
+function Translation(data, translator) {
+  $.extend(this, data);
+  this.hasContext = 'context' in data;
+  this.isPlural = 'originalPlural' in data;
+  this.isTranslated = 'translations' in data;
+  this.translator = translator;
+  this.translator.translations.push(this);
+}
+Translation.prototype = {
+  buildListItem: function() {
+    var my = this;
+    this.li = document.createElement('li');
+    this.li.ccmTranslation = this;
+    this.li.className = 'list-group-item clearfix' + (this.isTranslated ? ' list-group-item-success' : '');
+    var sub = document.createElement('span');
+    sub.textContent = sub.textText = this.original;
+    this.li.appendChild(sub);
+    this.liTranslated = document.createElement('span');
+    this.translationUpdated(true);
+    this.li.appendChild(this.liTranslated);
+    this.translator.$list[0].appendChild(this.li);
+    this.li.onclick = function() {
+      my.translator.setCurrentTranslation(my);
+    };
+  },
+  translationUpdated: function(skipSetClass) {
+    this.liTranslated.textContent = this.liTranslated.textText = (this.isTranslated ? this.translations[0] : '');
+    if(skipSetClass !== true) {
+      if(this.isTranslated) {
+        $(this.li).addClass('list-group-item-success');
+      } else {
+        $(this.li).removeClass('list-group-item-success');
+      }
+    }
+  },
+  translatedSaved: function(translations) {
+    if(translations === null) {
+      delete this.translations;
+      this.isTranslated = false;
+    } else {
+      this.translations = translations;
+      this.isTranslated = true;
+    }
+    this.translationUpdated();
+  },
+  applyFilter: function() {
+    var shown = true;
+    var f = this.translator.appliedFilter;
+    if((f.showTranslated === false) && (this.isTranslated === true)) {
+      shown = false;
+    } else if((f.showUntranslated === false) && (this.isTranslated === false)) {
+      shown = false;
+    } else {
+      if(f.text.length > 0) {
+        var textFound = false;
+        if((textFound === false) && f.searchInOriginals) {
+          if(this.original.toLowerCase().indexOf(f.lowerCaseText) >= 0) {
+            textFound = true;
+          } else if(this.isPlural && (this.originalPlural.toLowerCase().indexOf(f.lowerCaseText) >= 0)) {
+            textFound = true;
+          }
+        }
+        if((textFound === false) && f.searchInTranslations && this.isTranslated) {
+          for(var n = this.translations.length, i = 0; i < n && (textFound === false); i++) {
+            if(this.translations[i].toLowerCase().indexOf(f.lowerCaseText) >= 0) {
+              textFound = true;
+            }
+          }
+        }
+        if((textFound === false) && f.searchInContexts && this.hasContext) {
+          if(this.context.toLowerCase().indexOf(f.lowerCaseText) >= 0) {
+            textFound = true;
+          }
+        }
+        if(textFound === false) {
+          shown = false;
+        }
+      }
+    }
+    this.li.style.display = shown ? '' : 'none';
+  }
+};
+
+var TranslationView = (function() {
+
+  function Base(translation, multiline) {
+    this.translation = translation;
+    this.multiline = multiline;
+    this.element = this.multiline ? 'textarea rows="8"' : 'input type="text"';
+    this.$container = this.translation.translator.UI.$translation;
+    this.$container.empty();
+    this.$container.closest('.panel').css('visibility', 'visible');
+    this.buildOriginalUI();
+    this.buildTranslationUI();
+    if(('comments' in this.translation) || ('context' in this.translation) || ('references' in this.translation)) {
+      var $dl;
+      this.$container.append($dl = $('<dl />'));
+      if ('comments' in this.translation) {
+        $dl
+          .append($('<dt />').text(i18n.Comments))
+          .append($('<dd />').text(this.translation.comments))
+        ;
+      }
+      if ('context' in this.translation) {
+        $dl
+          .append($('<dt />').text(i18n.Context))
+          .append($('<dd />').text(this.translation.context))
+        ;
+      }
+      if ('references' in this.translation) {
+        var $dd;
+        $dl
+          .append($('<dt />').text(i18n.References))
+          .append($dd = $('<dd style="overflow: hidden; white-space: pre" />').text(this.translation.references.join('\n')))
+        ;
+        $dd.attr('title', $dd.text());
+      }
+    }
+    var $li = $(this.translation.li);
+    $li.addClass('list-group-item-info');
+    var newScrollTop = null;
+    var $ul = $li.closest('ul');
+    var liTop = $li.position().top - $ul.position().top;
+    var ulTop = $ul.scrollTop();
+    if(liTop < 0) {
+      newScrollTop = ulTop + liTop;
+    }
+    else {
+      var liBottom = liTop + $li.outerHeight();
+      var ulBottom = $ul.height();
+      if(liBottom > ulBottom) {
+        newScrollTop = ulTop + (liBottom - ulBottom);
+      }
+    }
+    if(newScrollTop !== null) {
+      $ul.animate({scrollTop: newScrollTop}, 50);
+    }
+  }
+  Base.prototype = {
+    isDirty: function() {
+      var translated = this.getTranslated();
+      if(translated === null) {
+        return this.translation.isTranslated ? true : false;
+      }
+      if (this.translation.isTranslated === false) {
+        return true;
+      }
+      var dirty = false;
+      for(var n = translated.length, i = 0; i < n; i++) {
+        if(translated[i] !== this.translation.translations[i]) {
+          dirty = true;
+          break;
+        }
+      }
+      return dirty;
+    },
+    dispose: function() {
+      $(this.translation.li).removeClass('list-group-item-info');
+      this.$container.empty().closest('.panel').css('visibility', 'hidden');
+    }
+  };
+
+  function Singular(translation) {
+    Base.call(this, translation, (translation.original.indexOf("\n") >= 0) ? true : false);
+  }
+  $.extend(true, Singular.prototype, Base.prototype, {
+    buildOriginalUI: function() {
+      this.$container
+        .append($('<div class="form-group" />')
+          .append($('<label class="control-label" />').text(i18n.Original_String))
+          .append($('<' + this.element + ' class="form-control" readonly="readonly" />').val(this.translation.original))
+        )
+      ;
+    },
+    buildTranslationUI: function() {
+      this.$container
+        .append($('<div class="form-group" />')
+          .append($('<label class="control-label" />').text(i18n.Translation))
+          .append(this.$translated = $('<' + this.element + ' class="form-control" />').val(this.translation.isTranslated ? this.translation.translations[0] : ''))
+        )
+      ;
+      this.$translated.focus();
+    },
+    getTranslated: function(forSave) {
+      var s = $.trim(this.$translated.val());
+      return (s.length > 0) ? [s] : null;
+    }
+  });
+
+  function Plural(translation) {
+    Base.call(this, translation, ((translation.original.indexOf("\n") >= 0) || (translation.originalPlural.indexOf("\n") >= 0)) ? true : false);
+  }
+  $.extend(true, Plural.prototype, Base.prototype, {
+    buildOriginalUI: function() {
+      this.$container
+        .append($('<div class="form-group" />')
+          .append($('<label class="control-label" />').text(i18n.Singular_Original_String))
+          .append($('<' + this.element + ' class="form-control" readonly="readonly" />').val(this.translation.original))
+        )
+        .append($('<div class="form-group" />')
+          .append($('<label class="control-label" />').text(i18n.Plural_Original_String))
+          .append($('<' + this.element + ' class="form-control" readonly="readonly" />').val(this.translation.originalPlural))
+        )
+      ;
+    },
+    showTranslationTab: function(key, focalize) {
+      this.$tabHeaders.find('li.active').removeClass('active');
+      this.$tabBodies.find('.tab-pane.active').removeClass('active');
+      this.$tabHeaders.find('li[data-key="' + key + '"]').addClass('active');
+      var $pane = this.$tabBodies.find('.tab-pane[data-key="' + key + '"]').addClass('active');
+      if(focalize) {
+        $pane.find('textarea,input').focus();
+      }
+    },
+    buildTranslationUI: function() {
+      var my = this;
+      var uniquePrefix = 'ccm-translator' + this.translation.translator.index + '-translation';
+      this.$container
+        .append($('<div class="form-group" />')
+          .append($('<label class="control-label" />').text(i18n.Translation))
+          .append(this.$tabHeaders = $('<ul class="nav nav-tabs" />'))
+          .append(this.$tabBodies = $('<div class="tab-content" />'))
+        )
+      ;
+      var index = 0;
+      this.$translated = {};
+      var firstKey = null;
+      $.each(this.translation.translator.plurals, function(key, examples) {
+        if (firstKey === null) {
+          firstKey = key;
+        }
+        my.$tabHeaders.append($('<li data-key="' + key + '"' + ((index === 0) ? ' class="active"' : '') + ' />')
+          .append($('<a href="#' + uniquePrefix + '-' + key + '" />')
+            .text(i18n.PluralNames[key])
+          )
+        );
+        my.$tabBodies.append($('<div id="' + uniquePrefix + '-' + key + '" class="tab-pane' + ((index === 0) ? ' active' : '') + '"  data-key="' + key + '" style="padding: 20px" />')
+          .append($('<p />').text(i18n.ExamplePH.replace(/%s/, examples)))
+          .append(my.$translated[key] = $('<' + my.element + ' class="form-control" />').val(my.translation.isTranslated ? my.translation.translations[index] : ''))
+        );
+        index++;
+      });
+      this.$tabHeaders.find('a').on('click', function(e) {
+        e.preventDefault();
+        my.showTranslationTab($(this).closest('li').attr('data-key'));
+      });
+      this.$translated[firstKey].focus();
+    },
+    getTranslated: function(forSave) {
+      var my = this;
+      var result = [];
+      var some = false, firstNotFilled = null;
+      $.each(this.translation.translator.plurals, function(key) {
+        var s = $.trim(my.$translated[key].val());
+        if (s.length > 0) {
+          some = true;
+        } else if(firstNotFilled === null) {
+          firstNotFilled = key;
+        }
+        result.push(s);
+      });
+      if (some === false) {
+        return null;
+      }
+      if ((firstNotFilled !== null) && (forSave === true)) {
+        this.showTranslationTab(firstNotFilled, true);
+        window.alert(i18n.Please_fill_in_all_plurals);
+        return false;
+      }
+      return result;
+    }
+  });
+
+  return {Singular: Singular, Plural: Plural};
+})();
+
+function Translator(data) {
+  this.index = translatorsCount++;
+  this.containerID = data.container;
+  this.height = data.height;
+  this.saveAction = data.saveAction;
+  this.plurals = $.extend(true, {}, data.plurals);
+  this.translations = [];
+  this.fuzzySupport = (data.fuzzySupport === false) ? false : null;
+  for (var i = 0, n = data.translations.length; i < n; i++) {
+    new Translation(data.translations[i], this);
+  }
+  this.saving = false;
+}
+Translator.prototype = {
+  launch: function() {
+    var my = this;
+    this.UI = {};
+    this.UI.$container = $(this.containerID);
+    delete this.containerID;
+    var height = this.height;
+    delete this.height;
+    if((!height) || (height < 200)) {
+      height = 200;
+    }
+    this.UI.$container
+      .append($('<div class="row" />')
+        .append($('<div class="col-md-12" />')
+          .append($('<div class="panel panel-info" />')
+            .append($('<div class="panel-heading" />')
+              .append($('<div class="panel-title" />').text(i18n.Filter))
+            )
+            .append($('<div class="panel-body" />')
+              .append($('<div class="input-group">')
+                .append(this.UI.$searchText = $('<input type="text" class="form-control" />')
+                  .attr('placeholder', i18n.Search_for_)
+                )
+                .append($('<div class="input-group-btn" />')
+                  .append(this.UI.$searchButton = $('<button type="button" class="btn btn-primary"><span class="fa fa-search"></span></button>'))
+                  .append($('<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" />')
+                    .append($('<span class="caret" />'))
+                    .append($('<span class="sr-only" />').text(i18n.Toggle_Dropdown))
+                  )
+                  .append($('<ul class="dropdown-menu dropdown-menu-right" role="menu" />')
+                    .append($('<li />')
+                      .append(this.UI.$searchInOriginals = $('<a href="javascript:void(0)" />')
+                        .text(' ' + i18n.Search_in_originals)
+                        .prepend($('<i class="fa" />'))
+                      )
+                    )
+                    .append($('<li />')
+                      .append(this.UI.$searchInTranslations = $('<a href="javascript:void(0)" />')
+                        .text(' ' + i18n.Search_in_translations)
+                        .prepend($('<i class="fa" />'))
+                      )
+                    )
+                    .append($('<li />')
+                      .append(this.UI.$searchInContexts = $('<a href="javascript:void(0)" />')
+                        .text(' ' + i18n.Search_in_contexts)
+                        .prepend($('<i class="fa" />'))
+                      )
+                    )
+                    .append('<li class="divider"></li>')
+                    .append($('<li />')
+                      .append(this.UI.$showUnapproved = $('<a href="javascript:void(0)" />')
+                        .text(' ' + i18n.Show_unapproved)
+                        .prepend($('<i class="fa" />'))
+                      )
+                    )
+                    .append($('<li />')
+                      .append(this.UI.$showApproved = $('<a href="javascript:void(0)" />')
+                        .text(' ' + i18n.Show_approved)
+                        .prepend($('<i class="fa" />'))
+                      )
+                    )
+                    .append('<li class="divider"></li>')
+                    .append($('<li />')
+                      .append(this.UI.$showTranslated = $('<a href="javascript:void(0)" />')
+                        .text(' ' + i18n.Show_translated)
+                        .prepend($('<i class="fa" />'))
+                      )
+                    )
+                    .append($('<li />')
+                      .append(this.UI.$showUntranslated = $('<a href="javascript:void(0)" />')
+                        .text(' ' + i18n.Show_untranslated)
+                        .prepend($('<i class="fa" />'))
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+      .append($('<div class="row" />')
+        .append($('<div class="col-md-7 ccm-translator-col-original" />')
+          .append($('<div class="panel panel-primary" />')
+            .append($('<div class="panel-heading clearfix" />')
+              .append($('<span />').text(i18n.Original_String))
+              .append($('<span />').text(i18n.Translation))
+            )
+            .append(this.$list = $('<ul class="list-group" />')
+              .css('height', height + 'px')
+            )
+          )
+        )
+        .append($('<div class="col-md-5 ccm-translator-col-translations" />')
+          .append($('<div class="panel panel-primary" />')
+            .append($('<div class="panel-heading" />').text(i18n.Translate))
+            .append(this.UI.$translation = $('<div class="panel-body" />'))
+            .append($('<div class="panel-footer" />')
+              .append($('<button class="btn btn-primary ccm-translator-savecontinue" />')
+                .text(i18n.Save_and_Continue)
+                .on('click', function() {
+                  my.saveAndContinue();
+                })
+              )
+              .append($('<small class="text-muted" style="margin-left: 20px" />').text(i18n.TAB))
+              .append($('<small class="text-muted" style="margin-left: 20px" />').text(i18n.TAB_SHIFT))
+            )
+          )
+        )
+      )
+    ;
+    var n = this.translations.length;
+    if(n < MAX_TRANSLATIONS_FOR_FASTSEARCH) {
+      this.UI.$searchButton.remove();
+      var hAutosearchTimer = null;
+      this.UI.$searchText.on('change keydown keyup keypress', function() {
+        if (hAutosearchTimer) {
+          clearTimeout(hAutosearchTimer);
+        }
+        hAutosearchTimer = setTimeout(function() {
+          hAutosearchTimer = null;
+          my.filter();
+        }, 100);
+      });
+    } else {
+      this.UI.$searchText.on('keypress', function(e) {
+        if ((e.keyCode || e.charCode) === 13) {
+          my.filter();
+        }
+      });
+      this.UI.$searchButton.on('click', function() {
+        my.filter();
+      });
+    }
+    var someContexts = false;
+    for(var i = 0; i < n; i++) {
+      this.translations[i].buildListItem();
+      if (this.translations[i].hasContext) {
+        someContexts = true;
+      }
+    }
+    this.appliedFilter = {
+      text: '',
+      searchInOriginals: true,
+      searchInTranslations: true,
+      searchInContexts: false,
+      showUnapproved: true,
+      showApproved: true,
+      showTranslated: true,
+      showUntranslated: true
+    };
+    this.viewAppliedFilter();
+    this.UI.$searchInOriginals.on('click', function() {
+      my.filter({searchInOriginals: !my.appliedFilter.searchInOriginals});
+    });
+    this.UI.$searchInTranslations.on('click', function() {
+      my.filter({searchInTranslations: !my.appliedFilter.searchInTranslations});
+    });
+    this.UI.$showTranslated.on('click', function() {
+      my.filter({showTranslated: !my.appliedFilter.showTranslated});
+    });
+    this.UI.$showUntranslated.on('click', function() {
+      my.filter({showUntranslated: !my.appliedFilter.showUntranslated});
+    });
+    if(this.fuzzySupport) {
+      this.UI.$showUnapproved.on('click', function() {
+        my.filter({showUnapproved: !my.appliedFilter.showUnapproved});
+      });
+      this.UI.$showApproved.on('click', function() {
+        my.filter({showApproved: !my.appliedFilter.showApproved});
+      });
+    } else {
+      this.UI.$showUnapproved.closest('li').prev().remove();
+      this.UI.$showUnapproved.remove();
+      this.UI.$showApproved.remove();
+    }
+    if(someContexts) {
+      this.UI.$searchInContexts.on('click', function() {
+        my.filter({searchInContexts: !my.appliedFilter.searchInContexts});
+      });
+    } else {
+      this.UI.$searchInContexts.remove();
+    }
+    $(window).on('beforeunload', function() {
+      if(my.currentTranslationView && my.currentTranslationView.isDirty()) {
+        return i18n.AskDiscardDirtyTranslation;
+      }
+    });
+    if(n > 0) {
+      this.setCurrentTranslation(this.translations[0]);
+    }
+    this.UI.$container.on('keydown', function(e) {
+      switch (e.keyCode || e.which) {
+        case 9:
+          e.preventDefault();
+          my.saveAndContinue(e.shiftKey ? true : false);
+          break;
+      }
+    });
+  },
+  viewAppliedFilter: function() {
+    var f = this.appliedFilter;
+    if(this.UI.$searchText.text() !== f.text) {
+      this.UI.$searchText.text(f.text); 
+    }
+    this.UI.$searchInOriginals.find('i').removeClass('fa-check-square-o fa-square-o').addClass(f.searchInOriginals ? 'fa-check-square-o' : 'fa-square-o');
+    this.UI.$searchInTranslations.find('i').removeClass('fa-check-square-o fa-square-o').addClass(f.searchInTranslations ? 'fa-check-square-o' : 'fa-square-o');
+    this.UI.$searchInContexts.find('i').removeClass('fa-check-square-o fa-square-o').addClass(f.searchInContexts ? 'fa-check-square-o' : 'fa-square-o');
+    this.UI.$showUnapproved.find('i').removeClass('fa-check-square-o fa-square-o').addClass(f.showUnapproved ? 'fa-check-square-o' : 'fa-square-o');
+    this.UI.$showApproved.find('i').removeClass('fa-check-square-o fa-square-o').addClass(f.showApproved ? 'fa-check-square-o' : 'fa-square-o');
+    this.UI.$showTranslated.find('i').removeClass('fa-check-square-o fa-square-o').addClass(f.showTranslated ? 'fa-check-square-o' : 'fa-square-o');
+    this.UI.$showUntranslated.find('i').removeClass('fa-check-square-o fa-square-o').addClass(f.showUntranslated ? 'fa-check-square-o' : 'fa-square-o');
+  },
+  filter: function(f) {
+    var my = this;
+    var newFilter = $.extend(true, {}, this.appliedFilter, f, {text: this.UI.$searchText.val()});
+    var needApplyFilter = false;
+    $.each(newFilter, function(key, value) {
+      if(value === my.appliedFilter[key]) {
+        return;
+      }
+      switch(key) {
+        case 'searchInOriginals':
+        case 'searchInTranslations':
+        case 'searchInContexts':
+          if(my.appliedFilter.text === '') {
+            return;
+          }
+          break;
+      }
+      needApplyFilter = true;
+      return false;
+    });
+    this.appliedFilter = newFilter;
+    this.viewAppliedFilter();
+    if(!needApplyFilter) {
+      return;
+    }
+    this.appliedFilter.lowerCaseText = this.appliedFilter.text.toLowerCase();
+    var n = this.translations.length;
+    for(var i = 0; i < n; i++) {
+      this.translations[i].applyFilter();
+    }
+  },
+  setCurrentTranslation: function(translation) {
+    if (this.saving) {
+      return false;
+    }
+    if(this.currentTranslationView) {
+      if(this.currentTranslationView.translation === translation) {
+        return;
+      }
+      if(this.currentTranslationView.isDirty()) {
+        if(!window.confirm(i18n.AskDiscardDirtyTranslation)) {
+          return;
+        }
+      }
+      this.currentTranslationView.dispose();
+      this.currentTranslationView = null;
+    }
+    if(translation === null) {
+      return;
+    }
+    this.currentTranslationView = translation.isPlural ? new TranslationView.Plural(translation) :  new TranslationView.Singular(translation);
+  },
+  setSaving: function(saving) {
+    this.saving = !!saving;
+    var $btn = this.UI.$container.find('button.ccm-translator-savecontinue');
+    if(this.saving) {
+      $btn.css('width', $btn.outerWidth() + 'px').html('<span class="fa fa-spinner fa-spin"></span>');
+    } else {
+      $btn.css('width', 'auto').text(i18n.Save_and_Continue);
+    }
+  },
+  saveAndContinue: function(backward) {
+    var my = this;
+    if (this.saving) {
+      return;
+    }
+    if(this.currentTranslationView.isDirty() === false) {
+      this.gotoNextTranslation(backward);
+      return;
+    }
+    var translated = this.currentTranslationView.getTranslated(true);
+    if (translated === false) {
+      return;
+    }
+    var translation = this.currentTranslationView.translation;
+    var postData = {};
+    postData.id = translation.id;
+    if(translated === null) {
+      postData.clear = 1;
+    } else {
+      postData.translated = translated;
+    }
+    this.setSaving(true);
+    $.ajax({
+      type: 'POST',
+      url: this.saveAction,
+      data: postData,
+      dataType: 'json'
+    })
+    .always(function() {
+      my.setSaving(false);
+    })
+    .fail(function (data) {
+      if (data.responseJSON && data.responseJSON.errors) {
+        window.alert(data.responseJSON.errors.join("\n"));
+      } else {
+        window.alert(data.responseText);
+      }
+    })
+    .success(function(response) {
+      if(response && response.error) {
+        window.alert(response.errors.join("\n"));
+        return;
+      }
+      translation.translatedSaved(translated);
+      my.gotoNextTranslation(backward);
+    });
+  },
+  gotoNextTranslation: function(backward) {
+    var $lis = this.$list.children(':visible');
+    if($lis.length === 0) {
+      this.setCurrentTranslation(null);
+      return;
+    }
+    var newIndex = 0;
+    if (this.currentTranslationView) {
+      var currentIndex = $.inArray(this.currentTranslationView.translation.li, $lis);
+      if (backward) {
+        if (currentIndex >= 0) {
+          newIndex = currentIndex - 1;
+          if (newIndex < 0) {
+            newIndex = $lis.length - 1;
+          }
+        }
+      } else {
+        if ((currentIndex >= 0) && (currentIndex < $lis.length - 1)) {
+          newIndex = currentIndex + 1;
+        }
+      }
+    }
+    this.setCurrentTranslation($lis[newIndex].ccmTranslation);
+  }
+};
+
+var Startup = (function() {
+  var domReady = false, readyTranslators = [];
+  function launch() {
+    while(readyTranslators.length > 0) {
+      readyTranslators.splice(0, 1)[0].launch();
+    }
+  }
+  return {
+    setDomReady: function() {
+      domReady = true;
+      if(readyTranslators.length) {
+        launch();
+      }
+    },
+    setTranslatorReady: function(translator) {
+      readyTranslators.push(translator);
+      if(domReady) {
+        launch();
+      }
+    }
+  };
+})();
+
+window.ccmTranslator = {
+  setI18NDictionart: function(i18nDictionary) {
+    $.extend(true, i18n, i18nDictionary);
+  },
+  initialize: function(data) {
+    Startup.setTranslatorReady(new Translator(data));
+  }
+};
+  
+$(document).ready(function() {
+  Startup.setDomReady();
+});
+
+})();

--- a/web/concrete/js/build/core/translator.js
+++ b/web/concrete/js/build/core/translator.js
@@ -646,7 +646,7 @@ Translator.prototype = {
         window.alert(data.responseText);
       }
     })
-    .success(function(response) {
+    .done(function(response) {
       if(response && response.error) {
         window.alert(response.errors.join("\n"));
         return;

--- a/web/concrete/single_pages/dashboard/system/multilingual/translate_interface.php
+++ b/web/concrete/single_pages/dashboard/system/multilingual/translate_interface.php
@@ -1,281 +1,177 @@
-<?defined('C5_EXECUTE') or die("Access Denied.")?>
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 
-<?$valt = Loader::helper('validation/token')?>
+/* @var $this PageView */
 
-<?php
-if ($this->controller->getTask() == 'translate_po') { ?>
+$valt = Loader::helper('validation/token');
 
-    <style type="text/css">
-        div.ccm-translate-site-interface-messages span.original {
-            float: left;
-            width: 50%;
-            height: 20px;
-            overflow: hidden;
+if ($this->controller->getTask() == 'translate_po') {
+
+    /* @var $section \Concrete\Core\Multilingual\Page\Section\Section */
+    ?>
+    <script>
+    $(document).ready(function() {
+      ccmTranslator.setI18NDictionart({
+        AskDiscardDirtyTranslation: <?php echo json_encode(t("The current item has changed.\nIf you proceed you will lose your changes.\n\nDo you want to proceed anyway?")); ?>,
+        Comments: <?php echo json_encode(t('Comments')); ?>,
+        Context: <?php echo json_encode(t('Context')); ?>,
+        ExamplePH: <?php echo json_encode(t('Example: %s')); ?>,
+        Filter: <?php echo json_encode(t('Filter')); ?>,
+        Original_String: <?php echo json_encode(t('Original String')); ?>,
+        Please_fill_in_all_plurals: <?php echo json_encode(t('Please fill-in all plural forms')); ?>,
+        Plural_Original_String: <?php echo json_encode(t('Plural Original String')); ?>,
+        References: <?php echo json_encode(t('References')); ?>,
+        Save_and_Continue: <?php echo json_encode(t('Save & Continue')); ?>,
+        Search_for_: <?php echo json_encode(t('Search for...')); ?>,
+        Search_in_contexts: <?php echo json_encode(t('Search in contexts')); ?>,
+        Search_in_originals: <?php echo json_encode(t('Search in originals')); ?>,
+        Search_in_translations: <?php echo json_encode(t('Search in translations')); ?>,
+        Show_approved: <?php echo json_encode(t('Show approved')); ?>,
+        Show_translated: <?php echo json_encode(t('Show translated')); ?>,
+        Show_unapproved: <?php echo json_encode(t('Show unapproved')); ?>,
+        Show_untranslated: <?php echo json_encode(t('Show untranslated')); ?>,
+        Singular_Original_String: <?php echo json_encode(t('Singular Original String')); ?>,
+        Toggle_Dropdown: <?php echo json_encode(t('Toggle Dropdown')); ?>,
+        TAB: <?php echo json_encode(t('[TAB] Forward')); ?>,
+        TAB_SHIFT: <?php echo json_encode(t('[SHIFT]+[TAB] Backward')); ?>,
+        Translate: <?php echo json_encode(t('Translate')); ?>,
+        Translation: <?php echo json_encode(t('Translation')); ?>,
+        PluralNames: {
+          zero: <?php echo json_encode(tc('PluralCase', 'Zero')); ?>,
+          one: <?php echo json_encode(tc('PluralCase', 'One')); ?>,
+          two: <?php echo json_encode(tc('PluralCase', 'Two')); ?>,
+          few: <?php echo json_encode(tc('PluralCase', 'Few')); ?>,
+          many: <?php echo json_encode(tc('PluralCase', 'Many')); ?>,
+          other: <?php echo json_encode(tc('PluralCase', 'Other')); ?>
         }
-        div.ccm-translate-site-interface-messages span.translation {
-            float: left;
-            width: 50%;
-            height: 20px;
-            overflow: hidden;
-        }
-
-        div.ccm-translate-site-interface-messages li.list-group-item {
-            transition: all 0.2s linear;
-        }
-
-        li.list-group-item:hover {
-            background-color: #dedede;
-            cursor:pointer;
-        }
-
-        div.ccm-translate-site-interface-messages ul.list-group {
-            overflow: scroll;
-        }
-
-        div.ccm-translate-site-interface-translate form.translate-form {
-            display:none;
-        }
-    </style>
-
-
-    <div class="row">
-        <div class="ccm-translate-site-interface-messages col-md-7">
-            <div class="panel panel-primary">
-                <div class="panel-heading clearfix">
-                    <span class="original"><?=t('Original String')?></span>
-                    <span class="translation"><?=t('Translation')?></span>
-                </div>
-                <ul class="list-group">
-                    <? foreach($translations as $string) { ?>
-                        <li class="list-group-item <? if ($string->hasTranslation()) { ?>list-group-item-success<? } ?> clearfix" data-translation="<?=$string->getRecordID()?>">
-                            <span class="original">
-                                <?=$string->getOriginal()?>
-                            </span>
-                            <span class="translation">
-                                <?=$string->getTranslation()?>
-                            </span>
-                        </li>
-                    <? } ?>
-                </ul>
-                <div class="panel-footer"></div>
-            </div>
-        </div>
-        <div class="col-md-5 ccm-translate-site-interface-translate">
-            <div class="panel panel-primary">
-                <div class="panel-heading"><?=t('Translate')?></div>
-                <div class="panel-body">
-                    <? foreach($translations as $string) { ?>
-                        <form method="post" class="translate-form" action="<?=$controller->action('save_translation')?>" data-form="<?=$string->getRecordID()?>">
-                            <input type="hidden" name="mtID" value="<?=$string->getRecordID()?>">
-                            <div class="form-group">
-                                <label class="control-label" for="original-<?=$string->getRecordID()?>"><?=t('Original String')?></label>
-                                <textarea class="form-control" disabled id="original-<?=$string->getRecordID()?>" rows="8"><?=h($string->getOriginal())?></textarea>
-                            </div>
-                            <div class="form-group">
-                                <label class="control-label" for="translation-<?=$string->getRecordID()?>"><?=t('Translation')?></label>
-                                <textarea class="form-control" name="msgstr" id="translation-<?=$string->getRecordID()?>" rows="8"><?=h($string->getTranslation())?></textarea>
-                            </div>
-                            <button class="btn btn-primary" data-btn="save"><?=t('Save &amp; Continue')?></button>
-                            <div class="spacer-row-3"></div>
-                        </form>
-                    <? } ?>
-                </div>
-                <div class="panel-footer"></div>
-            </div>
-        </div>
-    </div>
+      });
+      ccmTranslator.initialize({
+        container: '#ccm-translator-interface',
+        height: $(window).height() - 300,
+        saveAction: <?php echo json_encode($this->action('save_translation')); ?>,
+        plurals: <?php echo json_encode($section->getPluralsCases()); ?>,
+        translations: <?php echo json_encode($translations, $jsonOptions); ?>,
+        fuzzySupport: false
+      })
+    });
+    </script>
+    <div id="ccm-translator-interface" class="ccm-translator"></div>
 
     <div class="ccm-dashboard-header-buttons">
-        <a href="<?=$controller->action('view')?>" class="btn btn-default"><?=t('Back to List')?></a>
+        <a href="<?php echo $controller->action('view'); ?>" class="btn btn-default"><?php echo t('Back to List'); ?></a>
     </div>
+    <?php
 
-    <script type="text/javascript">
-        var $translateBody;
-        activateTranslation = function(id) {
-            var $listItem = $('li[data-translation=' + id + ']'),
-                $form = $('form[data-form=' + id + ']');
+} else {
 
-            $('div.ccm-translate-site-interface-messages li.list-group-item-info').removeClass('list-group-item-info');
-            $('div.ccm-translate-site-interface-translate form').hide();
-            $listItem.addClass('list-group-item-info');
-            $form.concreteAjaxForm({
-                success: function(r) {
-                    $listItem.addClass('list-group-item-success');
-                    return;
-                }
-            }).show();
-        }
+    if (!is_dir(DIR_LANGUAGES_SITE_INTERFACE) || !is_writable(DIR_LANGUAGES_SITE_INTERFACE)) {
+        ?><div class="alert alert-warning"><?php echo t('You must create the directory %s and make it writable before you may run this tool. Additionally, all files within this directory must be writable.', DIR_LANGUAGES_SITE_INTERFACE); ?></div><?php
+    }
+    $nav = Loader::helper('navigation');
+    Loader::model('section', 'multilingual');
+    $pages = \Concrete\Core\Multilingual\Page\Section\Section::getList();
+    $defaultSourceLocale = Config::get('concrete.multilingual.default_source_locale');
 
-        saveAndContinue = function(id) {
-            var $activeTranslation = $('li.list-group-item-info'),
-                $next = $activeTranslation.next(),
-                $form = $('form[data-form=' + id + ']');
-
-            if ($next.length) {
-                activateTranslation($next.attr('data-translation'));
-                $form.submit();
-            }
-        }
-
-        $(function() {
-            $translateBody = $('div.ccm-translate-site-interface-translate div.panel-body');
-            var windowHeight = $(window).height();
-            var height = windowHeight - 350;
-            var existingHeight = $translateBody.find('form').height();
-            if (existingHeight > height) {
-                height = existingHeight;
-            }
-
-            $('div.ccm-translate-site-interface-messages ul.list-group').css('height', height);
-            $('div.ccm-translate-site-interface-translate div.panel-body').css('height', height);
-
-            $('div.ccm-translate-site-interface-messages').on('click', 'li[data-translation]', function() {
-                var translation = $(this).attr('data-translation');
-                activateTranslation(translation);
-            });
-
-            $('div.ccm-translate-site-interface-translate').on('click', 'button[data-btn=save]', function() {
-                var translation = $(this).attr('data-translation');
-                saveAndContinue(translation);
-            });
-
-            $(window).on('keydown', function(e) {
-                if (e.keyCode == 40) {
-                    e.preventDefault();
-                    var $activeTranslation = $('li.list-group-item-info');
-                    saveAndContinue($activeTranslation.attr('data-translation'));
-                }
-
-                if (e.keyCode == 38) {
-                    e.preventDefault();
-                    var $activeTranslation = $('li.list-group-item-info'),
-                        $previous = $activeTranslation.prev();
-                    if ($previous.length) {
-                        activateTranslation($previous.attr('data-translation'));
-                    }
-                }
-            });
-
-            activateTranslation($('div.ccm-translate-site-interface-messages li[data-translation]:first-child').attr('data-translation'));
-        });
-
-
-
-    </script>
-
-    <?
-}  else {
-
-	if (!is_dir(DIR_LANGUAGES_SITE_INTERFACE) || !is_writable(DIR_LANGUAGES_SITE_INTERFACE)) { ?>
-		<div class="alert alert-warning"><?=t('You must create the directory %s and make it writable before you may run this tool. Additionally, all files within this directory must be writable.', DIR_LANGUAGES_SITE_INTERFACE)?></div>
-	<? } ?>
-
-	<?php
-	$nav = Loader::helper('navigation');
-	Loader::model('section', 'multilingual');
-	$pages = \Concrete\Core\Multilingual\Page\Section\Section::getList();
-	$defaultSourceLocale = Config::get('concrete.multilingual.default_source_locale');
-
-	$ch = Core::make('multilingual/interface/flag');
-	$dh = Core::make('helper/date');
-	if (count($pages) > 0) { ?>
-
-<div class="ccm-dashboard-content-full">
-    <div class="table-responsive">
-        <table class="ccm-search-results-table">
-            <thead>
-            <tr>
-                <th>&nbsp;</th>
-                <th><span><?=t("Name")?></span></th>
-                <th><span><?=t('Locale')?></span></th>
-                <th colspan="2"><span><?=t('Completion')?></span></th>
-                <th><span><?=t('Last Updated')?></span></th>
-                <th></th>
-            </tr>
-            </thead>
-            <tbody>
-            <? foreach($pages as $pc) {
-                $pcl = \Concrete\Core\Multilingual\Page\Section\Section::getByID($pc->getCollectionID());?>
-                <tr>
-                    <td><?=$ch->getSectionFlagIcon($pc)?></td>
-                    <td>
-                        <a href="<?=$nav->getLinkToCollection($pc)?>">
-                            <?=$pc->getCollectionName()?>
-                        </a>
-                    </td>
-                    <td style="white-space: nowrap">
-                        <?php echo $pc->getLocale(); ?>
-                        <? if ($pc->getLocale() != $defaultSourceLocale) { ?>
-                            <a href="#" class="icon-link launch-tooltip" title="<?=REL_DIR_LANGUAGES_SITE_INTERFACE?>/<?=$pc->getLocale()?>.mo"><i class="fa fa-question-circle"></i></a>
-                        <? } ?>
-                    </td>
-                    <td style="width: 40%">
-                        <? if ($pc->getLocale() != $defaultSourceLocale) { ?>
-                            <?
-                            $data = $extractor->getSectionSiteInterfaceCompletionData($pc);
-                            ?>
-                            <div class="progress">
-                                <div class="progress-bar" style="width: <?=$data['completionPercentage']?>%">&nbsp;</div>
-                            </div>
-                        <? } ?>
-                    </td>
-                    <td style="white-space: nowrap">
-                        <? if ($pc->getLocale() != $defaultSourceLocale) { ?>
-                            <span class="percent"><?=$data['completionPercentage']?>%</span> - <span class="translated"><?=$data['translatedCount']?></span> <?=t('of')?> <span class="total"><?=$data['messageCount']?></span>
-                        <? } ?>
-                    </td>
-                    <td>
-                        <? if ($pc->getLocale() != $defaultSourceLocale) {
-                            if (file_exists(DIR_LANGUAGES_SITE_INTERFACE . '/' . $pc->getLocale() . '.mo'))
-                                print $dh->formatDateTime(filemtime(DIR_LANGUAGES_SITE_INTERFACE . '/' . $pc->getLocale() . '.mo'), true);
-                            else
-                                print t('File not found.');
+    $ch = Core::make('multilingual/interface/flag');
+    $dh = Core::make('helper/date');
+    if (count($pages) > 0) {
+        ?>
+        <div class="ccm-dashboard-content-full">
+            <div class="table-responsive">
+                <table class="ccm-search-results-table">
+                    <thead>
+                    <tr>
+                        <th>&nbsp;</th>
+                        <th><span><?php echo t('Name'); ?></span></th>
+                        <th><span><?php echo t('Locale'); ?></span></th>
+                        <th colspan="2"><span><?php echo t('Completion'); ?></span></th>
+                        <th><span><?php echo t('Last Updated'); ?></span></th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody><?php
+                        foreach ($pages as $pc) {
+                            $pcl = \Concrete\Core\Multilingual\Page\Section\Section::getByID($pc->getCollectionID());
+                            ?><tr>
+                                <td><?php echo $ch->getSectionFlagIcon($pc); ?></td>
+                                <td><a href="<?php echo $nav->getLinkToCollection($pc); ?>"><?php echo $pc->getCollectionName(); ?></a></td>
+                                <td style="white-space: nowrap"><?php
+                                    echo $pc->getLocale();
+                                    if ($pc->getLocale() != $defaultSourceLocale) {
+                                        ?><a href="#" class="icon-link launch-tooltip" title="<?php echo REL_DIR_LANGUAGES_SITE_INTERFACE; ?>/<?php echo $pc->getLocale(); ?>.mo"><i class="fa fa-question-circle"></i></a><?php
+                                    }
+                                ?></td>
+                                <td style="width: 40%"><?php
+                                    if ($pc->getLocale() != $defaultSourceLocale) {
+                                        $data = $extractor->getSectionSiteInterfaceCompletionData($pc);
+                                        ?><div class="progress">
+                                            <div class="progress-bar" style="width: <?php echo $data['completionPercentage']; ?>%">&nbsp;</div>
+                                        </div><?php
+                                    }
+                                ?></td>
+                                <td style="white-space: nowrap"><?php
+                                    if ($pc->getLocale() != $defaultSourceLocale) {
+                                        ?>
+                                        <span class="percent"><?php echo $data['completionPercentage']; ?>%</span>
+                                        -
+                                        <?php echo t(/*i18n: %1$s is the partial number, %2$s is the total number. Example: 2 of 3 */'%1$s of %2$s', '<span class="translated">'.$data['translatedCount'].'</span>', '<span class="total">'.$data['messageCount'].'</span>'); ?>
+                                        <?php
+                                    }
+                                ?></td>
+                                <td><?php
+                                    if ($pc->getLocale() != $defaultSourceLocale) {
+                                        if (file_exists(DIR_LANGUAGES_SITE_INTERFACE.'/'.$pc->getLocale().'.mo')) {
+                                            echo $dh->formatDateTime(filemtime(DIR_LANGUAGES_SITE_INTERFACE.'/'.$pc->getLocale().'.mo'), true);
+                                        } else {
+                                            echo t('File not found.');
+                                        }
+                                    } else {
+                                        echo t('N/A');
+                                    }
+                                ?></td>
+                                <?php
+                                if ($pc->getLocale() == $defaultSourceLocale) {
+                                    ?><td></td><?php
+                                } else {
+                                    ?><td><a href="<?php echo $this->action('translate_po', $pc->getCollectionID()); ?>" class="icon-link"><i class="fa fa-pencil"></i></a></td><?php
+                                }
+                                ?>
+                            </tr><?php
                         }
-                        else
-                            echo t('N/A'); ?>
-                    </td>
-                    <? if ($pc->getLocale() == $defaultSourceLocale) { ?>
-                        <td></td>
-                    <? } else { ?>
-                        <td><a href="<?=$this->action('translate_po', $pc->getCollectionID())?>" class="icon-link"><i class="fa fa-pencil"></i></a></td>
-                    <? } ?>
-                </tr>
-            <? } ?>
-            </tbody>
-        </table>
-    </div>
-</div>
-
-        <?
-        if (is_dir(DIR_LANGUAGES_SITE_INTERFACE) && is_writable(DIR_LANGUAGES_SITE_INTERFACE)) { ?>
-
-        <form method="post" action="<?=$controller->action('submit')?>">
-        <div class="ccm-dashboard-header-buttons btn-group">
-            <button class="btn btn-default" type="submit" name="action" value="reload"><?=t('Reload Strings')?></button>
-            <button class="btn btn-default" type="submit" name="action" value="export"><?=t('Export to .PO')?></button>
-            <?=$valt->output()?>
-            <button class="btn btn-danger" type="button" data-dialog="reset" value="reset"><?=t('Reset All')?></button>
+                    ?></tbody>
+                </table>
+            </div>
         </div>
-        </form>
 
+        <?php
+        if (is_dir(DIR_LANGUAGES_SITE_INTERFACE) && is_writable(DIR_LANGUAGES_SITE_INTERFACE)) {
+            ?>
+            <form method="post" action="<?php echo $controller->action('submit'); ?>">
+                <div class="ccm-dashboard-header-buttons btn-group">
+                    <button class="btn btn-default" type="submit" name="action" value="reload"><?php echo t('Reload Strings'); ?></button>
+                    <button class="btn btn-default" type="submit" name="action" value="export"><?php echo t('Export to .PO'); ?></button>
+                    <?php echo $valt->output(); ?>
+                    <button class="btn btn-danger" type="button" data-dialog="reset" value="reset"><?php echo t('Reset All'); ?></button>
+                </div>
+            </form>
 
             <div style="display: none">
-                <div id="ccm-dialog-reset-languages" class="ccm-ui">
-                    <?
+                <div id="ccm-dialog-reset-languages" class="ccm-ui"><?php
                     $u = new User();
-                    if ($u->isSuperUser()) { ?>
-                    <form method="post" class="form-stacked" style="padding-left: 0px" action="<?=$view->action('reset_languages')?>">
-                        <?=Loader::helper("validation/token")->output('reset_languages')?>
-                        <p><?=t('Are you sure? This will remove all translations from all languages, in the database and in your site PO files. This cannot be undone.')?></p>
-                    </form>
-                    <div class="dialog-buttons">
-                        <button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
-                        <button class="btn btn-danger pull-right" onclick="$('#ccm-dialog-reset-languages form').submit()"><?=t('Confirm Reset')?></button>
-                    </div>
-                    <? } else { ?>
-                        <p><?=t("Only the admin user may reset all languages.")?></p>
-                    <? } ?>
-                </div>
+                    if ($u->isSuperUser()) {
+                        ?>
+                        <form method="post" class="form-stacked" style="padding-left: 0px" action="<?php echo $view->action('reset_languages'); ?>">
+                            <?php echo Loader::helper("validation/token")->output('reset_languages'); ?>
+                            <p><?php echo t('Are you sure? This will remove all translations from all languages, in the database and in your site PO files. This cannot be undone.'); ?></p>
+                        </form>
+                        <div class="dialog-buttons">
+                            <button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?php echo t('Cancel'); ?></button>
+                            <button class="btn btn-danger pull-right" onclick="$('#ccm-dialog-reset-languages form').submit()"><?php echo t('Confirm Reset'); ?></button>
+                        </div>
+                        <?php
+                    } else {
+                        ?><p><?php echo t('Only the admin user may reset all languages.'); ?></p><?php
+                    }
+                ?></div>
             </div>
 
             <script type="text/javascript">
@@ -285,14 +181,16 @@ if ($this->controller->getTask() == 'translate_po') { ?>
                             element: '#ccm-dialog-reset-languages',
                             modal: true,
                             width: 320,
-                            title: '<?=t("Reset Languages")?>',
-                            height: 'auto'
+                            title: <?php echo json_encode(t('Reset Languages')); ?>,
+                            height: 'auto',
+                            resizable: false
                         });
                     });
                 });
             </script>
-
-        <? } ?>
+            <?php
+        }
+        ?>
 
         <style type="text/css">
             table.ccm-search-results-table div.progress {
@@ -300,9 +198,9 @@ if ($this->controller->getTask() == 'translate_po') { ?>
             }
         </style>
 
+        <?php
+    } else {
+        ?><p><?php echo t('You have not created any multilingual content sections yet.'); ?></p><?php
+    }
 
-	<? } else { ?>
-		<p><?=t('You have not created any multilingual content sections yet.')?></p>
-	<? } ?>
-<? } ?>
-</div>
+}

--- a/web/concrete/src/Multilingual/Service/Extractor.php
+++ b/web/concrete/src/Multilingual/Service/Extractor.php
@@ -192,14 +192,14 @@ class Extractor
                 $data['msgstrPlurals'] = implode("\x00", $plurals);
             }
             $comments = $translation->getExtractedComments();
-            if (!empty($plurals)) {
+            if (!empty($comments)) {
                 $data['comments'] = implode("\n", $comments);
             }
             $references = $translation->getReferences();
             if (!empty($references)) {
                 $data['reference'] = '';
                 foreach ($translation->getReferences() as $reference) {
-                    $data['reference'] .= implode(':', $reference) . "\n";
+                    $data['reference'] .= (isset($reference[1]) ? implode(':', $reference) : $reference[0]) . "\n";
                 }
             }
             $flags = $translation->getFlags();


### PR DESCRIPTION
Here's a new interface to translate for the *Translate Site Interface* page.

Highlights:
- search function (in source language and/or in destination language and/or in contexts)
- show only translated and/or untranslated strings
- support for plural strings
- single-line translations for single-line source strings
- show comments, contexts and references
- saving via ajax

=====

Before:

![translator-from](https://cloud.githubusercontent.com/assets/928116/6389782/70784482-bda7-11e4-936c-e0cb2bbf6c74.png)

=====

After:

![translator-to](https://cloud.githubusercontent.com/assets/928116/6389787/758d8e5a-bda7-11e4-85ec-d9c2d158cf48.png)
