### PR TITLE
Add missing 'use Exception'

### DIFF
--- a/web/concrete/src/Error/Error.php
+++ b/web/concrete/src/Error/Error.php
@@ -3,6 +3,7 @@
 namespace Concrete\Core\Error;
 use Loader;
 use stdClass;
+use Exception;
 
 class Error {
 


### PR DESCRIPTION
Concrete\Core\Error\Error uses `\Exception` but calls it `Exception`...