### PR TITLE
Prevent empty textarea overriding HTML block content

### DIFF
--- a/web/concrete/blocks/html/form_setup_html.php
+++ b/web/concrete/blocks/html/form_setup_html.php
@@ -16,8 +16,13 @@
         var editor = ace.edit("ccm-block-html-value");
         editor.setTheme("ace/theme/eclipse");
         editor.getSession().setMode("ace/mode/html");
+        refreshTextarea(editor.getValue());
         editor.getSession().on('change', function() {
-            $('#ccm-block-html-value-textarea').val(editor.getValue());
+            refreshTextarea(editor.getValue());
         });
     });
+
+    function refreshTextarea(contents) {
+      $('#ccm-block-html-value-textarea').val(contents);
+    }
 </script>


### PR DESCRIPTION
If the HTML block is saved without any changes (thus not triggering the on change event), the textarea remains empty and the content is lost.

This fix copies the editor contents into the textarea upon loading the block for editing, ensuring the content isn't emptied if nothing has changed.