### PR TITLE
Fixes #845, HTML block tooltip getting cut off

### DIFF
--- a/web/concrete/css/build/vendor/jquery-ui/jquery-ui.less
+++ b/web/concrete/css/build/vendor/jquery-ui/jquery-ui.less
@@ -1339,7 +1339,7 @@ button.ui-button::-moz-focus-inner {
   box-sizing: content-box ; /* See issue #412 */
   /* concrete5 */
   width: 300px;
-  overflow: hidden;
+  overflow: visible;
   outline: 0;
   background-clip: padding-box;
   background-color: #FFFFFF;
@@ -1357,7 +1357,6 @@ button.ui-button::-moz-focus-inner {
   /* concrete5 */
   /*z-index: 1050; */
   z-index: @index-level-dialog;
-  -webkit-transform: translate3d(0px, 0, 0);
   max-width: 100%;
   /* end concrete5 */
 


### PR DESCRIPTION
Changing overflow to visible on .ui-dialog prevents the tooltip from being cut off (see #845).

Chrome/Webkit has a bug where translate3d() on a position: fixed element causes it to behave as if it were position: absolute (also visible in the #845 screenshot, the tooltip isn't connected to the cursor).