### PR TITLE
use URL alias instead of \Concrete\Core\Routing\URL

### DIFF
--- a/web/concrete/src/Block/View/BlockView.php
+++ b/web/concrete/src/Block/View/BlockView.php
@@ -112,7 +112,7 @@ class BlockView extends AbstractView
                     $arguments = func_get_args();
                     $arguments[] = $b->getBlockID();
                     array_unshift($arguments, $c);
-                    return call_user_func_array(array('\Concrete\Core\Routing\URL', 'page'), $arguments);
+                    return call_user_func_array(array('URL', 'page'), $arguments);
                 }
             }
         } catch (Exception $e) {

--- a/web/concrete/src/Routing/Redirect.php
+++ b/web/concrete/src/Routing/Redirect.php
@@ -20,7 +20,7 @@ class Redirect {
 	* Redirects to a concrete5 resource.	
 	 */
 	public static function to() {
-		$url = BASE_URL . call_user_func_array('\Concrete\Core\Routing\URL::to', func_get_args());
+		$url = BASE_URL . call_user_func_array(array('URL', 'to'), func_get_args());
 		$r = static::createRedirectResponse($url, 302, array());
 		return $r;
 	}

--- a/web/concrete/src/Routing/URL.php
+++ b/web/concrete/src/Routing/URL.php
@@ -14,7 +14,7 @@ class URL {
 	public static function page(Page $c, $action = false) {
 		$args = func_get_args();
 		$args[0] = Loader::helper('text')->encodePath($c->getCollectionPath());
-		return call_user_func_array(array('\Concrete\Core\Routing\URL', 'to'), $args);
+		return call_user_func_array(array('URL', 'to'), $args);
 	}
 
 	public static function to($path, $action = false) {
@@ -74,7 +74,7 @@ class URL {
         }
         $route = Router::route($data);
         array_unshift($arguments, $route);
-        return call_user_func_array(array('\Concrete\Core\Routing\URL', 'to'), $arguments);
+        return call_user_func_array(array('URL', 'to'), $arguments);
     }
 
 }


### PR DESCRIPTION
Fully namespaced classname of \Concrete\Core\Routing\URL was still in use in several places. Replaced it with the URL alias so it can be safely overridden.