### PR TITLE
Remove duplicated index in BlockFeatureAssignments table

### DIFF
--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -1963,15 +1963,9 @@
         <col>cID</col>
         <col>cvID</col>
     </index>
-    <index name="faID">
-        <col>faID</col>
-        <col>cID</col>
-        <col>cvID</col>
-    </index>
     <index name="bID">
         <col>bID</col>
     </index>
-
   </table>
   <table name="CollectionAttributeValues">
     <field name="cID" type="I" size="10">


### PR DESCRIPTION
We have this block of code duplicated for the BlockFeatureAssignments  table:
```xml
<index name="faID">
  <col>faID</col>
  <col>cID</col>
  <col>cvID</col>
</index>
```

...it's not always true that [repetita iuvant](http://en.wikipedia.org/wiki/List_of_Latin_phrases_(R)#repetita_iuvant)... ;)