### PR TITLE
Upgrade Translation Library to v1.3.2

### DIFF
--- a/web/concrete/composer.json
+++ b/web/concrete/composer.json
@@ -57,6 +57,6 @@
         "tedivm/stash": "0.12.1",
         "lusitanian/oauth": "~0.3",
         "oryzone/oauth-user-data": "~1.0@dev",
-        "mlocati/concrete5-translation-library": "1.3.1"
+        "mlocati/concrete5-translation-library": "1.3.2"
     }
 }

--- a/web/concrete/composer.lock
+++ b/web/concrete/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2223b7f3d98711ad57f8b39ce586e4d3",
+    "hash": "1679d36aa3214275ce68e37d6275c30d",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -1536,16 +1536,16 @@
         },
         {
             "name": "mlocati/concrete5-translation-library",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlocati/concrete5-translation-library.git",
-                "reference": "571510db126e039c6329309fb2d4a531f8cb4a87"
+                "reference": "cec2c3f46b23c1bbaa775d21286eadc44632c87e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/571510db126e039c6329309fb2d4a531f8cb4a87",
-                "reference": "571510db126e039c6329309fb2d4a531f8cb4a87",
+                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/cec2c3f46b23c1bbaa775d21286eadc44632c87e",
+                "reference": "cec2c3f46b23c1bbaa775d21286eadc44632c87e",
                 "shasum": ""
             },
             "require": {
@@ -1582,7 +1582,7 @@
                 "translate",
                 "translation"
             ],
-            "time": "2015-02-21 16:29:24"
+            "time": "2015-03-09 08:49:21"
         },
         {
             "name": "mobiledetect/mobiledetectlib",


### PR DESCRIPTION
See https://github.com/mlocati/concrete5-translation-library/releases/tag/1.3.2