### PR TITLE
File manager multi select

### DIFF
--- a/web/concrete/elements/files/search.php
+++ b/web/concrete/elements/files/search.php
@@ -23,6 +23,7 @@ $req = $flr->getSearchRequest();
                 <option data-bulk-action-type="dialog" data-bulk-action-title="<?=t('Duplicate')?>" data-bulk-action-url="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/files/duplicate" data-bulk-action-dialog-width="500" data-bulk-action-dialog-height="400"><?=t('Copy')?></option>
  */ ?>
                 <option data-bulk-action-type="dialog" data-bulk-action-title="<?php echo t('Delete')?>" data-bulk-action-url="<?php echo URL::to('/ccm/system/dialogs/file/bulk/delete')?>" data-bulk-action-dialog-width="500" data-bulk-action-dialog-height="400"><?php echo t('Delete')?></option>
+                <option value="choose"><?php echo t('Choose')?></option>
             </select>
         </div>
         <div class="form-group">

--- a/web/concrete/js/build/core/file-manager/search.js
+++ b/web/concrete/js/build/core/file-manager/search.js
@@ -222,10 +222,10 @@
             onOpen: function(dialog) {
                 ConcreteEvent.unsubscribe('FileManagerSelectFile');
                 ConcreteEvent.subscribe('FileManagerSelectFile', function(e, data) {
-                    var multipleItemsSelected = Object.prototype.toString.call( data.fID ) === '[object Array]' ;
-                    if ( options.multipleSelection && !multipleItemsSelected ) {
+                    var multipleItemsSelected = (Object.prototype.toString.call( data.fID ) === '[object Array]');
+                    if (options.multipleSelection && !multipleItemsSelected) {
                         data.fID = [data.fID]; 
-                    } else if ( !options.multipleSelection && multipleItemsSelected  ) {
+                    } else if (!options.multipleSelection && multipleItemsSelected) {
                         if (data.fID.length > 1) {
                             $('.ccm-search-bulk-action option:first-child').prop('selected', 'selected');
                             alert(ccmi18n_filemanager.chosenTooMany);

--- a/web/concrete/js/build/core/file-manager/search.js
+++ b/web/concrete/js/build/core/file-manager/search.js
@@ -26,6 +26,10 @@
         my.setupFileUploads();
         my.setupEvents();
 
+        // Remove the multiple choice option from the dashboard menu
+        if ( 'menu' === options.mode ) {
+            $('.ccm-search-bulk-action option[value="choose"]').remove();
+        }
     }
 
     ConcreteFileManager.prototype = Object.create(ConcreteAjaxSearch.prototype);
@@ -144,7 +148,8 @@
             my.$element.on('mouseout.concreteFileManagerHoverFile', 'tr[data-file-manager-file]', function() {
                 $(this).removeClass('ccm-search-select-hover');
             });
-            my.$element.unbind('.concreteFileManagerChooseFile').on('click.concreteFileManagerChooseFile', 'tr[data-file-manager-file]', function() {
+            my.$element.unbind('.concreteFileManagerChooseFile').on('click.concreteFileManagerChooseFile', 'tr[data-file-manager-file]', function(e) {
+                if ( 'checkbox' === $(e.target).prop('type') ) return;
                 ConcreteEvent.publish('FileManagerBeforeSelectFile', {fID: $(this).attr('data-file-manager-file')});
                 ConcreteEvent.publish('FileManagerSelectFile', {fID: $(this).attr('data-file-manager-file')});
                 my.$downloadTarget.remove();
@@ -159,7 +164,11 @@
             itemIDs.push({'name': 'item[]', 'value': $(checkbox).val()});
         });
 
-        if (value == 'download') {
+        if (value == 'choose') {
+            var items = itemIDs.map(function (value) { return value.value; });
+            ConcreteEvent.publish('FileManagerBeforeSelectFile', { fID: items });
+            ConcreteEvent.publish('FileManagerSelectFile', { fID: items });
+        } else if (value == 'download') {
             my.$downloadTarget.get(0).src = CCM_TOOLS_PATH + '/files/download?' + jQuery.param(itemIDs);
         } else {
             ConcreteAjaxSearch.prototype.handleSelectedBulkAction.call(this, value, type, $option, $items);
@@ -184,6 +193,7 @@
 
         var options = {
             filters: [], // filters must be an array of objects ex: [{ field: Concrete.const.Controller.Search.Files.FILTER_BY_TYPE, type: Concrete.const.Core.File.Type.Type.T_IMAGE }]
+            multipleSelection: false, // Multiple selection switch
         };
 
         $.extend(options, opts);
@@ -209,9 +219,20 @@
             modal: true,
             data: data,
             title: ccmi18n_filemanager.title,
-            onOpen: function() {
+            onOpen: function(dialog) {
                 ConcreteEvent.unsubscribe('FileManagerSelectFile');
                 ConcreteEvent.subscribe('FileManagerSelectFile', function(e, data) {
+                    var multipleItemsSelected = Object.prototype.toString.call( data.fID ) === '[object Array]' ;
+                    if ( options.multipleSelection && !multipleItemsSelected ) {
+                        data.fID = [data.fID]; 
+                    } else if ( !options.multipleSelection && multipleItemsSelected  ) {
+                        if (data.fID.length > 1) {
+                            $('.ccm-search-bulk-action option:first-child').prop('selected', 'selected');
+                            alert(ccmi18n_filemanager.chosenTooMany);
+                            return;
+                        }
+                        data.fID = data.fID[0];
+                    }
                     jQuery.fn.dialog.closeTop();
                     callback(data);
                 });

--- a/web/concrete/tools/i18n_js.php
+++ b/web/concrete/tools/i18n_js.php
@@ -206,6 +206,7 @@ var ccmi18n_filemanager = {
     uploadComplete: "<?=t('Upload Complete')?>",
     uploadFailed: "<?=t('One or more files failed to upload')?>",
     uploadProgress: "<?=t('Upload Progress')?>",
+    chosenTooMany: "<?=t('You may only select a single file.')?>",
 
     PTYPE_CUSTOM: "<?//=FilePermissions::PTYPE_CUSTOM?>",
     PTYPE_NONE: "<?//=FilePermissions::PTYPE_NONE?>",


### PR DESCRIPTION
Added 'Choose' back to the bulk options menu within the file managers 'choose' mode as per #1799.

There is a new switch `multipleSelection` that is supplied as part of the dialog call, an example:

    ConcreteFileManager.launchDialog(function (data) {
        for(var i = 0; i < data.fID.length; i++) {
            ConcreteFileManager.getFileDetails(data.fID[i], function(r) {
                // Do your stuff
            });
         }
    }, { 'multipleSelection' : true });

If the switch is set to `true` an array of file IDs will be passed back, if the switch is not present or set to false you will get the standard object back, this preserves compatibility.

As per the last comment by @ahukkanen, I've disabled the auto selection only when a checkbox is clicked, you can click anywhere else on a row and get the selection functionality. The 'choose' bulk option is still available when multiple selection is disabled, I've added a prompt to alert users that try to select more than one file.

The only thing I will say is this will require IE 9+ as I use Array.map instead of looping, I'm assuming IE8 support was dropped long ago.

Check it out and let me know what you think.