### PR TITLE
Mark minify and combine as static

### DIFF
--- a/web/concrete/src/Asset/Asset.php
+++ b/web/concrete/src/Asset/Asset.php
@@ -63,9 +63,9 @@ abstract class Asset
 
     abstract public function getAssetType();
 
-    abstract public function minify($assets);
+    abstract public static function minify($assets);
 
-    abstract public function combine($assets);
+    abstract public static function combine($assets);
 
     abstract public function __toString();
 

--- a/web/concrete/src/Asset/CssAsset.php
+++ b/web/concrete/src/Asset/CssAsset.php
@@ -164,7 +164,7 @@ class CssAsset extends Asset
      * @param $assets
      * @return Asset[]
      */
-    public function combine($assets)
+    public static function combine($assets)
     {
         return self::process($assets, function($css, $assetPath, $targetPath) {
             return CSSAsset::changePaths($css, $assetPath, $targetPath);
@@ -175,7 +175,7 @@ class CssAsset extends Asset
      * @param $assets
      * @return Asset[]
      */
-    public function minify($assets)
+    public static function minify($assets)
     {
         return self::process($assets, function($css, $assetPath, $targetPath) {
             return \CssMin::minify(CSSAsset::changePaths($css, $assetPath, $targetPath));

--- a/web/concrete/src/Asset/JavascriptAsset.php
+++ b/web/concrete/src/Asset/JavascriptAsset.php
@@ -89,7 +89,7 @@ class JavascriptAsset extends Asset
      * @param Asset[] $assets
      * @return Asset[]
      */
-    public function combine($assets)
+    public static function combine($assets)
     {
         return self::process($assets, function($js, $assetPath, $targetPath) {
             return $js;
@@ -100,7 +100,7 @@ class JavascriptAsset extends Asset
      * @param Asset[] $assets
      * @return Asset[]
      */
-    public function minify($assets)
+    public static function minify($assets)
     {
         return self::process($assets, function($js, $assetPath, $targetPath) {
             return \JShrink\Minifier::minify($js);


### PR DESCRIPTION
minify() and combine() don't use any instance method/variabies, and they are called as static by `View->postProcessAssets()` (see https://github.com/concrete5/concrete5-5.7.0/blob/develop/web/concrete/src/View/View.php#L253 and https://github.com/concrete5/concrete5-5.7.0/blob/develop/web/concrete/src/View/View.php#L256)