### PR TITLE
Remove the border on the 'Powered by concrete5.' white label message

### DIFF
--- a/web/concrete/css/build/core/app/toolbar.less
+++ b/web/concrete/css/build/core/app/toolbar.less
@@ -206,7 +206,6 @@ div#ccm-toolbar {
       padding: 18px 24px 0px 24px;
       height: 30px;
       border-right: 0px !important;
-      border-left: 1px solid #ccc;
     }
 
   }


### PR DESCRIPTION
![2015-03-18_17-17-56](https://cloud.githubusercontent.com/assets/5735900/6703818/daa736a4-cd94-11e4-98e9-1bb39e532acb.png)

It is the 1px line between 'Add' and 'Powered', hard to see I know.