### PR TITLE
[WIP] Add Composer installer type

### DIFF
--- a/web/application/bootstrap/autoload.php
+++ b/web/application/bootstrap/autoload.php
@@ -6,5 +6,9 @@
  * ----------------------------------------------------------------------------
  */
 if (!@include(DIR_BASE_CORE . '/' . DIRNAME_VENDOR . '/autoload.php')) {
-    die('Third party libraries not installed. Make sure that composer has required libraries in the concrete/ directory.');
+    if (!@include(DIR_BASE_CORE . '/../' . DIRNAME_VENDOR . '/autoload.php')) {
+        if (!@include(DIR_BASE_CORE . '/../../' . DIRNAME_VENDOR . '/autoload.php')) {
+            die('Third party libraries not installed. Make sure that composer has required libraries in the concrete/ directory.');
+        }
+    }
 }

--- a/web/concrete/composer.json
+++ b/web/concrete/composer.json
@@ -9,14 +9,14 @@
             "url": "https://github.com/concrete5/flysystem"
         }
     ],
-	"name": "concrete5/concrete5-core",
-	"type": "concrete5-core",
+    "name": "concrete5/concrete5-core",
+    "type": "concrete5-core",
     "config": {
         "optimize-autoloader": true
     },
     "require": {
         "php": ">=5.3.3",
-		"composer/installers": "~1.0",
+        "composer/installers": "~1.0",
         "doctrine/dbal": "2.4.*",
         "symfony/class-loader": "2.5.*",
         "symfony/http-foundation": "2.5.*",

--- a/web/concrete/composer.json
+++ b/web/concrete/composer.json
@@ -9,11 +9,14 @@
             "url": "https://github.com/concrete5/flysystem"
         }
     ],
+	"name": "concrete5/concrete5-core",
+	"type": "concrete5-core",
     "config": {
         "optimize-autoloader": true
     },
     "require": {
         "php": ">=5.3.3",
+		"composer/installers": "~1.0",
         "doctrine/dbal": "2.4.*",
         "symfony/class-loader": "2.5.*",
         "symfony/http-foundation": "2.5.*",


### PR DESCRIPTION
Adds the Composer installer type `concrete5-core` as proposed in #360 to the composer.json file. 

As recommended the directory `web/concrete` should be split into a separate repository, if possible named `concrete5/concrete5-core` (#1508).

This repository could then be renamed to `concrete5/concrete5-cms` and the following composer.json could be added:

```
{
    "name": "project",
    "type": "concrete5-cms",
    "require": {
        "concrete5/concrete5-core": "5.7.*"
    }
}
```

As discussed in #360 updating concrete5 over the web makes little sense when using Composer - so I would recommend developers using Composer to set `array('marketplace' => array('enabled' => false))` in their setup.

The Composer installer type `concrete5-core` is currently waiting to be merged here: https://github.com/composer/installers/pull/225