### PR TITLE
Fix XSS in Translating site interface

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/system/multilingual/translate_interface.php
+++ b/web/concrete/controllers/single_page/dashboard/system/multilingual/translate_interface.php
@@ -188,11 +188,7 @@ class TranslateInterface extends DashboardPageController
                 }
                 $jsonTranslations[] = $jsonTranslation;
             }
-            $jsonOptions = 0;
-            if (defined('\JSON_UNESCAPED_SLASHES')) {
-                $jsonOptions |= \JSON_UNESCAPED_SLASHES;
-            }
-            $this->set('jsonOptions', $jsonOptions);
+
             $this->set('translations', $jsonTranslations);
         } else {
             $this->redirect('/dashboard/system/multilingual/translate_interface');

--- a/web/concrete/single_pages/dashboard/system/multilingual/translate_interface.php
+++ b/web/concrete/single_pages/dashboard/system/multilingual/translate_interface.php
@@ -49,7 +49,7 @@ if ($this->controller->getTask() == 'translate_po') {
         height: $(window).height() - 300,
         saveAction: <?php echo json_encode($this->action('save_translation')); ?>,
         plurals: <?php echo json_encode($section->getPluralsCases()); ?>,
-        translations: <?php echo json_encode($translations, $jsonOptions); ?>,
+        translations: <?php echo json_encode($translations); ?>,
         fuzzySupport: false
       })
     });


### PR DESCRIPTION
Removed this option which allowed unescaped slashes which allowed input to be evaluated.
@mlocati Any reason this was added? it only affected PHP 5.4+ and I don't see why it was needed.