### PR TITLE
Edit attributes and permissions for external links

### DIFF
--- a/web/concrete/blocks/autonav/controller.php
+++ b/web/concrete/blocks/autonav/controller.php
@@ -730,7 +730,7 @@ class Controller extends BlockController
 
         if ($this->displayUnavailablePages == false) {
             $tcp = new Permissions($tc);
-            if (!$tcp->canRead() && ($tc->getCollectionPointerExternalLink() == null)) {
+            if (!$tcp->canRead()) {
                 return false;
             }
         }

--- a/web/concrete/js/build/core/sitemap/search.js
+++ b/web/concrete/js/build/core/sitemap/search.js
@@ -145,6 +145,8 @@
                 '<li><a href="<%=item.link%>">' + ccmi18n_sitemap.visitExternalLink + '</a></li>' +
                 '<% if (item.cAlias == \'LINK\' && item.canEditPageProperties) { %>' +
                 '<li><a class="dialog-launch" dialog-width="350" dialog-height="260" dialog-title="' + ccmi18n_sitemap.editExternalLink + '" dialog-modal="false" dialog-append-buttons="true" href="' + CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/edit_external?cID=<%=item.cID%>">' + ccmi18n_sitemap.editExternalLink + '</a></li>' +
+                '<li><a class="dialog-launch" dialog-on-close="ConcreteSitemap.exitEditMode(<%=item.cID%>)" dialog-width="90%" dialog-height="70%" dialog-modal="false" dialog-title="' + ccmi18n_sitemap.pageAttributesTitle + '" href="' + CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/attributes?cID=<%=item.cID%>">' + ccmi18n_sitemap.pageAttributes + '</a></li>' +
+                '<li><a class="dialog-launch" dialog-on-close="ConcreteSitemap.exitEditMode(<%=item.cID%>)" dialog-width="500" dialog-height="630" dialog-modal="false" dialog-title="' + ccmi18n_sitemap.setPagePermissions + '" href="' + CCM_DISPATCHER_FILENAME + '/ccm/system/panels/details/page/permissions?cID=<%=item.cID%>">' + ccmi18n_sitemap.setPagePermissions + '</a></li>' +
                 '<% } %>' +
                 '<% if (item.canDeletePage) { %>' +
                 '<li><a class="dialog-launch" dialog-width="360" dialog-height="150" dialog-modal="false" dialog-title="' + ccmi18n_sitemap.deleteExternalLink + '" href="' + CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/delete_alias?cID=<%=item.cID%>">' + ccmi18n_sitemap.deleteExternalLink + '</a></li>' +

--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -710,8 +710,11 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             $newWindow = 0;
         }
 
-        $v = array($newCID, $cParentID, $uID, $cLink, $newWindow);
-        $q = "insert into Pages (cID, cParentID, uID, cPointerExternalLink, cPointerExternalLinkNewWindow) values (?, ?, ?, ?, ?)";
+        $cInheritPermissionsFromCID = $this->getPermissionsCollectionID();
+        $cInheritPermissionsFrom = "PARENT";
+
+        $v = array($newCID, $cParentID, $uID, $cInheritPermissionsFrom, $cInheritPermissionsFromCID, $cLink, $newWindow);
+        $q = "insert into Pages (cID, cParentID, uID, cInheritPermissionsFrom, cInheritPermissionsFromCID, cPointerExternalLink, cPointerExternalLinkNewWindow) values (?, ?, ?, ?, ?, ?, ?)";
         $r = $db->prepare($q);
 
         $res = $db->execute($r, $v);

--- a/web/concrete/src/Permission/Response/PageResponse.php
+++ b/web/concrete/src/Permission/Response/PageResponse.php
@@ -39,11 +39,6 @@ class PageResponse extends Response
     public function canViewPageInSitemap()
     {
         if (Config::get('concrete.permissions.model') != 'simple') {
-
-            if ($this->object->isExternalLink()) {
-                return true;
-            }
-
             $pk = $this->category->getPermissionKeyByHandle('view_page_in_sitemap');
             $pk->setPermissionObject($this->object);
             return $pk->validate();
@@ -54,9 +49,6 @@ class PageResponse extends Response
 
     public function canViewPage()
     {
-        if ($this->object->isExternalLink()) {
-            return true;
-        }
         return $this->validate('view_page');
     }
 
@@ -118,10 +110,6 @@ class PageResponse extends Response
 
     public function canEditPageProperties($obj = false)
     {
-        if ($this->object->isExternalLink()) {
-            return $this->canDeletePage();
-        }
-
         $pk = $this->category->getPermissionKeyByHandle('edit_page_properties');
         $pk->setPermissionObject($this->object);
         return $pk->validate($obj);
@@ -129,13 +117,6 @@ class PageResponse extends Response
 
     public function canDeletePage()
     {
-        if ($this->object->isExternalLink()) {
-            // then whether the person can delete/write to this page ACTUALLY dependent on whether the PARENT collection
-            // is writable
-            $cParentCollection = Page::getByID($this->object->getCollectionParentID(), "RECENT");
-            $cp2 = new Permissions($cParentCollection);
-            return $cp2->canAddExternalLink();
-        }
         return $this->validate('delete_page');
     }
 


### PR DESCRIPTION
## Why
I came across a [thread](http://www.concrete5.org/community/forums/customizing_c5/setting-permissions-on-external-page-links-in-autonav/) trying to figure out adding permissions and attributes for external links.

## How
Adds 'Attributes' and 'Permissions' to the dropdown for External Links in the Sitemap.

Adds default permissions (Guest view, Admin edit) to an external link upon creation.

Removed code which was overridding the permissions checks, now they behave the same as normal pages.