### PR TITLE
Avoid "Class does not exist" exception on Automated Jobs page

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/system/optimization/jobs.php
+++ b/web/concrete/controllers/single_page/dashboard/system/optimization/jobs.php
@@ -12,6 +12,10 @@ class Jobs extends DashboardPageController {
 	function on_start() 
 	{
 		parent::on_start();
+		// clear the environment overrides cache first
+		$env = \Environment::get();
+		$env->clearOverrideCache();
+
 		$installed = Job::getList();
 		$this->set('availableJobs', Job::getAvailableList(0)); 
 		$this->set('installedJobs', $installed); 


### PR DESCRIPTION
If we upload custom jobs in application directory, we will get ReflectionException.