### PR TITLE
check for proper column definition

### DIFF
--- a/web/concrete/src/Database/Schema/Parser/ArrayParser.php
+++ b/web/concrete/src/Database/Schema/Parser/ArrayParser.php
@@ -20,7 +20,12 @@ class ArrayParser
                 continue;
             }
             $table = $schema->createTable($tableName);
-            $table = $this->addColumns($table, $details['columns']);
+            if (isset($details['columns'])) {
+                $table = $this->addColumns($table, $details['columns']);
+            }
+            else {
+                throw new \Exception(t('Invalid column definition: %s in table %s', var_export($details, true), $tableName));
+            }
             $table->setPrimaryKey($details['primary']);
         }
 


### PR DESCRIPTION
I'm trying to create an attribute category in 5.7 but always received a message `illegal offset 'columns'`. It took me a few minutes to track it down as my package is pretty big. I'd recommend to improve the error reporting as shown in this PR.

You can reproduce it if you create an attribute category with this in it:

```php
protected $searchIndexFieldDefinition = 'lID I(11) UNSIGNED NOTNULL DEFAULT 0 PRIMARY';
```