### PR TITLE
Correct handling of requests on non-standard port

### DIFF
--- a/web/concrete/src/Application/Application.php
+++ b/web/concrete/src/Application/Application.php
@@ -416,7 +416,7 @@ class Application extends Container
         $url->getHost()->set($r->getHost());
         $url->getPath()->append($home);
 
-        if ($r->getPort() != 80 && ($url->getScheme()->get() != 'https' && $r->getPort() != 443)) {
+        if (($url->getScheme()->get() != 'http' || $r->getPort() != 80) && ($url->getScheme()->get() != 'https' || $r->getPort() != 443)) {
             $url->getPort()->set($r->getPort());
         }
 

--- a/web/concrete/src/Url/Resolver/PathUrlResolver.php
+++ b/web/concrete/src/Url/Resolver/PathUrlResolver.php
@@ -79,6 +79,7 @@ class PathUrlResolver implements UrlResolverInterface
     {
         // Normalize
         $url->setHost(null);
+        $url->setPort(null);
         $url->setScheme(null);
 
         if (\Config::get('concrete.seo.canonical_host')) {
@@ -94,7 +95,7 @@ class PathUrlResolver implements UrlResolverInterface
         $request_port = intval(\Request::getInstance()->getPort(), 10);
         if (\Config::get('concrete.seo.canonical_port')) {
             $url->getPort()->set(\Config::get('concrete.seo.canonical_port'));
-        } elseif ($request_port != 80 && ($url->getScheme()->get() == 'https' && $request_port != 443)) {
+        } elseif (($url->getScheme()->get() != 'http' || $request_port != 80) && ($url->getScheme()->get() != 'https' || $request_port != 443)) {
             $url->getPort()->set($request_port);
         }
     }

--- a/web/concrete/src/Url/Resolver/PathUrlResolver.php
+++ b/web/concrete/src/Url/Resolver/PathUrlResolver.php
@@ -92,11 +92,16 @@ class PathUrlResolver implements UrlResolverInterface
             $url->setScheme(\Request::getInstance()->getScheme());
         }
 
-        $request_port = intval(\Request::getInstance()->getPort(), 10);
         if (\Config::get('concrete.seo.canonical_port')) {
             $url->getPort()->set(\Config::get('concrete.seo.canonical_port'));
-        } elseif (($url->getScheme()->get() != 'http' || $request_port != 80) && ($url->getScheme()->get() != 'https' || $request_port != 443)) {
-            $url->getPort()->set($request_port);
+        } else {
+            $request_port = \Request::getInstance()->getPort();
+            if (isset($request_port)) {
+                $request_port = intval($request_port, 10);
+                if (($url->getScheme()->get() != 'http' || $request_port != 80) && ($url->getScheme()->get() != 'https' || $request_port != 443)) {
+                    $url->getPort()->set($request_port);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
The detection of non standard ports doesn't work (bug introduced in https://github.com/concrete5/concrete5-5.7.0/commit/3b077519b0a7a31f8633f4b9a93a94ce24855166).
Let's fix this.