### PR TITLE
raise error when config key isn't valid

### DIFF
--- a/web/concrete/src/Config/Repository/Repository.php
+++ b/web/concrete/src/Config/Repository/Repository.php
@@ -37,6 +37,9 @@ class Repository extends \Illuminate\Config\Repository
     public function save($key, $value)
     {
         list($namespace, $group, $item) = $this->parseKey($key);
+        if ($namespace === null || $group === null || $item === null) {
+            throw new \Exception(t('Your config key must be using the format "group.item"'));
+        }
         $collection = $this->getCollection($group, $namespace);
         unset($this->items[$collection]);
 


### PR DESCRIPTION
when one is porting old code where `$pkg->saveConfig('MY_PKG_CONFIG', 'value');` worked, this makes things easier to debug.

Just checking if everything is valid and giving the developer a hint about what's wrong...