### PR TITLE
Use date helper in date time template of page_attribute_display block

### DIFF
--- a/web/concrete/blocks/page_attribute_display/templates/date_time.php
+++ b/web/concrete/blocks/page_attribute_display/templates/date_time.php
@@ -1,7 +1,8 @@
 <?php
 defined('C5_EXECUTE') or die(_("Access Denied."));
+$dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service\Date */
 echo $this->controller->getOpenTag();
 echo $this->controller->getTitle();
 $format = (strlen($this->controller->dateFormat)?$this->controller->dateFormat:"m/d/y");
-echo date($format,strtotime($this->controller->getContent()));
+echo $dh->formatCustom($format, $this->controller->getContent());
 echo $this->controller->getCloseTag();


### PR DESCRIPTION
Makes use of correct locale on multilingual websites.