### PR TITLE
Phpstorm metadata for packages

### DIFF
--- a/web/concrete/src/Support/Symbol/MetadataGenerator.php
+++ b/web/concrete/src/Support/Symbol/MetadataGenerator.php
@@ -33,6 +33,14 @@ class MetadataGenerator
                 $file .= '\'' . $name . '\' instanceof ' . $className . ',' . PHP_EOL;
             }
         }
+
+        $file .= '), \Package::getByHandle(\'\') => array(';
+        $packages = \Package::getAvailablePackages(false);
+        foreach ($packages as $package) {
+            /** @var \Package $package */
+            $file .= '\'' . $package->getPackageHandle() . '\' instanceof \\' . get_class($package) . ',' . PHP_EOL;
+        }
+
         $file .= '));}';
 
         return $file;


### PR DESCRIPTION
This is similar to what I wrote to allow PhpStorm / IntelliJ to type detect \Core::make(), but now for \Package::getByHandle()