### PR TITLE
Correct the docblocks so autocompletion works

### DIFF
--- a/web/concrete/src/Database/DatabaseManager.php
+++ b/web/concrete/src/Database/DatabaseManager.php
@@ -58,7 +58,7 @@ class DatabaseManager
      * Legacy entry point
      *
      * @deprecated
-     * @return \Doctrine\DBAL\Connection
+     * @return \Concrete\Core\Database\Connection\Connection
      */
     public function getActiveConnection()
     {
@@ -69,7 +69,7 @@ class DatabaseManager
      * Legacy entry point
      *
      * @deprecated
-     * @return \Doctrine\DBAL\Connection
+     * @return \Concrete\Core\Database\Connection\Connection
      */
     public function get()
     {
@@ -80,7 +80,7 @@ class DatabaseManager
      * Get a database connection instance.
      *
      * @param  string $name
-     * @return \Doctrine\DBAL\Connection
+     * @return \Concrete\Core\Database\Connection\Connection
      */
     public function connection($name = null)
     {
@@ -130,7 +130,7 @@ class DatabaseManager
      * Reconnect to the given database.
      *
      * @param  string $name
-     * @return \Doctrine\DBAL\Connection
+     * @return \Concrete\Core\Database\Connection\Connection
      */
     public function reconnect($name = null)
     {
@@ -255,7 +255,7 @@ class DatabaseManager
     /**
      * Return all of the created connections.
      *
-     * @return \Doctrine\DBAL\Connection[]
+     * @return \Concrete\Core\Database\Connection\Connection[]
      */
     public function getConnections()
     {


### PR DESCRIPTION
\Concrete\Core\Database\Connection\Connection extends \Doctrine\DBAL\Connection so nothing breaks

But this allows fancy entity autocompletion! (don't forget to regenerate symbols!