### PR TITLE
Facebook Authentication

### DIFF
--- a/web/concrete/composer.json
+++ b/web/concrete/composer.json
@@ -34,7 +34,6 @@
         "michelf/php-markdown": "1.4.*@dev",
         "filp/whoops": "1.*",
         "pagerfanta/pagerfanta": "1.0.2",
-        "facebook/php-sdk": "3.2.*",
         "htmlawed/htmlawed": "dev-master",
         "mobiledetect/mobiledetectlib": "2.8.*",
         "monolog/monolog": "~1.7",

--- a/web/concrete/composer.lock
+++ b/web/concrete/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a5d0e07ffd89ac07e741e4f8f6173b65",
+    "hash": "55b8ee3fe13bf73ddc063dfd5b404144",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -353,7 +353,7 @@
                 {
                     "name": "Johannes Schmitt",
                     "email": "schmittjoh@gmail.com",
-                    "homepage": "http://jmsyst.com",
+                    "homepage": "https://github.com/schmittjoh",
                     "role": "Developer of wrapped JMSSerializerBundle"
                 }
             ],
@@ -427,9 +427,9 @@
                     "email": "kontakt@beberlei.de"
                 },
                 {
-                    "name": "Johannes M. Schmitt",
+                    "name": "Johannes Schmitt",
                     "email": "schmittjoh@gmail.com",
-                    "homepage": "http://jmsyst.com",
+                    "homepage": "https://github.com/schmittjoh",
                     "role": "Developer of wrapped JMSSerializerBundle"
                 }
             ],
@@ -816,52 +816,6 @@
                 "validator"
             ],
             "time": "2014-07-06 17:21:29"
-        },
-        {
-            "name": "facebook/php-sdk",
-            "version": "v3.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/facebook/facebook-php-sdk.git",
-                "reference": "6714042fa2f5979d4c64c7d11fb4bcab16bdf6cb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/facebook/facebook-php-sdk/zipball/6714042fa2f5979d4c64c7d11fb4bcab16bdf6cb",
-                "reference": "6714042fa2f5979d4c64c7d11fb4bcab16bdf6cb",
-                "shasum": ""
-            },
-            "require": {
-                "ext-curl": "*",
-                "ext-json": "*",
-                "php": ">=5.2.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "3.7.*"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache2"
-            ],
-            "authors": [
-                {
-                    "name": "Facebook",
-                    "homepage": "https://github.com/facebook/facebook-php-sdk/contributors"
-                }
-            ],
-            "description": "Facebook PHP SDK",
-            "homepage": "https://github.com/facebook/facebook-php-sdk",
-            "keywords": [
-                "facebook",
-                "sdk"
-            ],
-            "time": "2013-11-19 23:11:14"
         },
         {
             "name": "filp/whoops",
@@ -2761,12 +2715,12 @@
             "version": "v0.5.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/tedivm/JShrink.git",
+                "url": "https://github.com/tedious/JShrink.git",
                 "reference": "4b48e3d051cf0ab145db9df20d3292d91485bb60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tedivm/JShrink/zipball/4b48e3d051cf0ab145db9df20d3292d91485bb60",
+                "url": "https://api.github.com/repos/tedious/JShrink/zipball/4b48e3d051cf0ab145db9df20d3292d91485bb60",
                 "reference": "4b48e3d051cf0ab145db9df20d3292d91485bb60",
                 "shasum": ""
             },

--- a/web/concrete/src/Authentication/Type/Facebook/ServiceProvider.php
+++ b/web/concrete/src/Authentication/Type/Facebook/ServiceProvider.php
@@ -27,7 +27,8 @@ class ServiceProvider extends \Concrete\Core\Foundation\Service\Provider
                         \Config::get('auth.facebook.secret'),
                         (string) \URL::to($callback)
                     ),
-                    new SymfonySession(\Session::getFacadeRoot(), false));
+                    new SymfonySession(\Session::getFacadeRoot(), false),
+                    array('email'));
             }
         );
     }

--- a/web/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
+++ b/web/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
@@ -276,14 +276,19 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
             $last_name = strrev($reversed_last_name);
         }
 
+        $username = null;
         if ($this->supportsUsername()) {
             $username = $this->getUsername();
-        } elseif ($first_name || $last_name) {
-            $username = preg_replace('/[^a-z0-9\_]/', '_', strtolower($first_name . ' ' . $last_name));
-            $username = trim('_', preg_replace('/_{2,}/', '_', $username));
-        } else {
-            $username = preg_replace('/[^a-zA-Z0-9\_]/i', '_', strtolower(substr($email, 0, strpos($email, '@'))));
-            $username = trim('_', preg_replace('/_{2,}/', '_', $username));
+        }
+
+        if ($username === null) {
+            if ($first_name || $last_name) {
+                $username = preg_replace('/[^a-z0-9\_]/', '_', strtolower($first_name . ' ' . $last_name));
+                $username = trim(preg_replace('/_{2,}/', '_', $username), '_');
+            } else {
+                $username = preg_replace('/[^a-zA-Z0-9\_]/i', '_', strtolower(substr($email, 0, strpos($email, '@'))));
+                $username = trim(preg_replace('/_{2,}/', '_', $username), '_');
+            }
         }
 
         $unique_username = $username;


### PR DESCRIPTION
Fixes #1694
There were a couple of problems preventing Facebook auth from working:
* Email scope permission wasn't being requested
* Username was being used, which Facebook removed support for
* The fallback username code resulted in a username of `_`