### PR TITLE
Apply custom templates also to SubAreas

### DIFF
--- a/web/concrete/src/Block/View/BlockView.php
+++ b/web/concrete/src/Block/View/BlockView.php
@@ -161,6 +161,19 @@ class BlockView extends AbstractView
                         $bvt = new BlockViewTemplate($this->block);
                         if (!$bFilename && is_object($this->area)) {
                             $templates = $this->area->getAreaCustomTemplates();
+                            if ($this->area instanceof \Concrete\Core\Area\SubArea) {
+                                // if this is a SubArea (i.e. a column in a gridlayout),
+                                // then we also get look for and use any custom templates
+                                // that have been set for the original 'parent' area
+                                $parent_block = $this->area->getSubAreaBlockObject();
+                                if ($parent_block) {
+                                    $parent_templates = $parent_block->a->getAreaCustomTemplates();
+
+                                    // make sure that parent templates can be overwritten by
+                                    // custom templates set on the subarea itself
+                                    $templates = array_merge($parent_templates, $templates);
+                                }
+                            }
                             if (isset($templates[$this->block->getBlockTypeHandle()])) {
                                 $bFilename = $templates[$this->block->getBlockTypeHandle()];
                             }


### PR DESCRIPTION
When you set a custom template for an area (in code), then that custom template should also be applied when the user adds a gridlayout to that area.

The existing code fails when you have code such as

```php
	$a = new Area('Main');
	$a->enableGridContainer();
	$a->setCustomTemplate("image", "templates/my_template.php");
	$a->display($c);
```

and then add a gridlayout to the area. Any custom templates that have been set are ignored. That's probably not the intention, and this pull request addresses that.
