### PR TITLE
Apply custom templates also to SubAreas

### DIFF
--- a/web/concrete/src/Area/SubArea.php
+++ b/web/concrete/src/Area/SubArea.php
@@ -93,6 +93,21 @@ class SubArea extends Area
         return $this->arParentID;
     }
 
+    public function getAreaCustomTemplates($include_parent_templates=true) {
+        $these_templates = parent::getAreaCustomTemplates();
+
+        if ($include_parent_templates && $this->parentBlock && $this->parentBlock->a) {
+            // include parent templates if instructed to do so
+            $parent_templates = $this->parentBlock->a->getAreaCustomTemplates();
+
+            // make sure that parent templates can be overwritten by
+            // custom templates set on the subarea itself
+            return array_merge($parent_templates, $these_templates);
+        }
+
+        return $these_templates;
+    }
+
     /**
      * @param \SimpleXMLElement $p
      * @param \Page $page


### PR DESCRIPTION
When you set a custom template for an area (in code), then that custom template should also be applied when the user adds a gridlayout to that area.

This is a fix for the same issue as https://github.com/concrete5/concrete5-5.7.0/pull/2133, but the code is in SubArea instead of in BlockView. I think it's probably cleaner this way.