### PR TITLE
Lists core jobs on Awaiting Installation section

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/system/optimization/jobs.php
+++ b/web/concrete/controllers/single_page/dashboard/system/optimization/jobs.php
@@ -17,7 +17,7 @@ class Jobs extends DashboardPageController {
 		$env->clearOverrideCache();
 
 		$installed = Job::getList();
-		$this->set('availableJobs', Job::getAvailableList(0)); 
+		$this->set('availableJobs', Job::getAvailableList(1)); 
 		$this->set('installedJobs', $installed); 
 		$this->set('jobSets', JobSet::getList());
 		$this->set('auth', Job::generateAuth());


### PR DESCRIPTION
We can uninstall core jobs with just clicking trash icon, but we are not able to restore uninstalled jobs. I think it can be fixed easily, but I can't understand why core jobs are excluded.