### PR TITLE
use package handle of attribute key category

### DIFF
--- a/web/concrete/src/Backup/ContentImporter.php
+++ b/web/concrete/src/Backup/ContentImporter.php
@@ -872,7 +872,7 @@ class ContentImporter
                         $akc->getAttributeKeyCategoryHandle()
                     ) . 'Key', DIRNAME_CLASSES . '/Attribute/Key/' . $txt->camelcase(
                         $akc->getAttributeKeyCategoryHandle()
-                    ) . 'Key.php', (string) $ak['package']
+                    ) . 'Key.php', (string) $akc->getPackageHandle()
                 );
                 $ak = call_user_func(array($c1, 'import'), $ak);
             }


### PR DESCRIPTION
This commit doesn't work for me:
https://github.com/concrete5/concrete5-5.7.0/commit/80935590a040912bf71bde30e908a67f9ce52bdd

Got an XML like this:
```
<?xml version="1.0"?>
<concrete5-cif version="1.0">
    <attributekeys>
        <attributekey handle="exclude_subpages_from_nav" name="Exclude Subpages from Nav" package="webwende_theme"
                      searchable="1" indexed="1" type="boolean" category="collection" attributeset="navigation"/>
    </attributekeys>
</concrete5-cif>
```

Produces an error like this:
```
call_user_func() expects parameter 1 to be a valid callback, class '\Concrete\Package\MyPackage\Src\Attribute\Key\CollectionKey' not found
```

This is because you're checking the package of the attribute, but that's incorrect. You need to check the package of the attribute key category like I did in my pull request: https://github.com/concrete5/concrete5-5.7.0/pull/2100/files