### PR TITLE
Fix for CLI having invalid port

### DIFF
--- a/web/concrete/src/Url/Resolver/CanonicalUrlResolver.php
+++ b/web/concrete/src/Url/Resolver/CanonicalUrlResolver.php
@@ -50,7 +50,7 @@ class CanonicalUrlResolver implements UrlResolverInterface
             ) {
                 $url->setPort($port);
             }
-        } else {
+        } elseif ($port !== 0) {
             $url->setPort($port);
         }
 


### PR DESCRIPTION
https://github.com/concrete5/concrete5-5.7.0/blob/0a7e7e43293c541dd59ddc586f1a20772e9a899b/web/concrete/src/Url/Resolver/CanonicalUrlResolver.php#L38-L54 broke the CLI commands