### PR TITLE
Only set the port if we have one

### DIFF
--- a/web/concrete/src/Url/Resolver/CanonicalUrlResolver.php
+++ b/web/concrete/src/Url/Resolver/CanonicalUrlResolver.php
@@ -54,7 +54,7 @@ class CanonicalUrlResolver implements UrlResolverInterface
             ) {
                 $url->setPort($port);
             }
-        } else {
+        } elseif ($port) {
             $url->setPort($port);
         }
 


### PR DESCRIPTION
I was trying to run the generate constants via grunt (cli) but league/url kept throwing a runtime exception that the port must be greater than 0 there really is no reason to try and set the port if its not set to anything.