### PR TITLE
Make language selection on login work

### DIFF
--- a/web/concrete/controllers/single_page/login.php
+++ b/web/concrete/controllers/single_page/login.php
@@ -134,8 +134,24 @@ class Login extends PageController
         if (!$type || !($type instanceof AuthenticationType)) {
             return $this->view();
         }
-        $db = Loader::db();
         $u = new User();
+        if (Config::get('concrete.i18n.choose_language_login')) {
+            $userLocale = $this->post('USER_LOCALE');
+            if (is_string($userLocale) && ($userLocale !== '')) {
+                if ($userLocale !== 'en_US') {
+                    $availableLocales = Localization::getAvailableInterfaceLanguages();
+                    if (!in_array($userLocale, $availableLocales)) {
+                        $userLocale = '';
+                    }
+                }
+                if ($userLocale !== '') {
+                    if (Localization::activeLocale() !== $userLocale) {
+                        Localization::changeLocale($userLocale);
+                    }
+                    $u->setUserDefaultLanguage($userLocale);
+                }
+            }
+        }
 
         $ui = UserInfo::getByID($u->getUserID());
         $aks = UserAttributeKey::getRegistrationList();


### PR DESCRIPTION
Currently, if the configuration key `concrete.i18n.choose_language_login` is set, in the login page we ask the user's preferred language.
BTW, we don't do anything with that language: let's set the user's language to what he/she specify...