### PR TITLE
Don't change paths of urls that start with data: in CSS

### DIFF
--- a/web/concrete/src/Asset/CssAsset.php
+++ b/web/concrete/src/Asset/CssAsset.php
@@ -111,7 +111,7 @@ class CssAsset extends Asset
                     ? $m[1]
                     : substr($m[1], 1, strlen($m[1]) - 2);
 
-                if ('/' !== $url[0] && strpos($url, '//') === false) {
+                if ('/' !== $url[0] && strpos($url, '//') === false && strpos($url, 'data:') !== 0) {
                     $url = $change_prefix.$url;
                     $url = str_replace('/./', '/', $url);
                     do {


### PR DESCRIPTION
Without this fix the code translates from
```css
background-image:url(data:image/png;base64,...);
```
to
```css
background-image:url(some/relative/path/data:image/png;base64,...);
```
