### PR TITLE
Complete Redactor translations and use standard translation approach

### DIFF
--- a/web/concrete/controllers/frontend/assets_localization.php
+++ b/web/concrete/controllers/frontend/assets_localization.php
@@ -360,6 +360,15 @@ jQuery.Redactor.opts.langs[<?=json_encode($locale)?>] = {
   lightbox_link_type_iframe_options: <?=json_encode(t('Frame Options'))?>,
   lightbox_link_type_iframe_width: <?=json_encode(t('Width'))?>,
   lightbox_link_type_iframe_height: <?=json_encode(t('Height'))?>,
+  customStyles: <?=json_encode(t('Custom Styles'))?>,
+  remove_font: <?=json_encode(t('Remove font'))?>,
+  change_font_family: <?=json_encode(t('Change font family'))?>,
+  remove_font_size: <?=json_encode(t('Remove font size'))?>,
+  change_font_size: <?=json_encode(t('Change font size'))?>,
+  remove_style: <?=json_encode(t('Remove Style'))?>,
+  insert_character: <?=json_encode(t('Insert Character'))?>,
+  undo: <?=json_encode(t('Undo'))?>,
+  redo: <?=json_encode(t('Redo'))?>,
   /* end concrete5 */
   underline: <?=json_encode(t('Underline'))?>,
   alignment: <?=json_encode(t('Alignment'))?>,
@@ -374,16 +383,6 @@ jQuery.each(jQuery.Redactor.opts.langs.en, function(key, value) {
     jQuery.Redactor.opts.langs[<?=json_encode($locale)?>][key] = value;
   }
 });
-
-var ccmi18n_redactor = {
-  remove_font: <?=json_encode(t('Remove font'))?>,
-  change_font_family: <?=json_encode(t('Change font family'))?>,
-  remove_font_size: <?=json_encode(t('Remove font size'))?>,
-  change_font_size: <?=json_encode(t('Change font size'))?>,
-  cancel: <?=json_encode(t('Cancel'))?>,
-  save: <?=json_encode(t('Save'))?>,
-  remove_style: <?=json_encode(t('Remove Style'))?>
-};
 <?php
 
     }

--- a/web/concrete/js/build/core/redactor/inline.js
+++ b/web/concrete/js/build/core/redactor/inline.js
@@ -8,7 +8,7 @@ RedactorPlugins.concrete5inline = function() {
 
             var obj = this;
             this.$toolbar.addClass("ccm-inline-toolbar");
-            this.$toolbar.append($('<li class="ccm-inline-toolbar-button ccm-inline-toolbar-button-cancel"><button id="ccm-redactor-cancel-button" type="button" class="btn btn-mini">' + ccmi18n_redactor.cancel + '</button></li><li class="ccm-inline-toolbar-button ccm-inline-toolbar-button-save"><button id="ccm-redactor-save-button" type="button" class="btn btn-primary btn-mini">' + ccmi18n_redactor.save + '</button></li>'));
+            this.$toolbar.append($('<li class="ccm-inline-toolbar-button ccm-inline-toolbar-button-cancel"><button id="ccm-redactor-cancel-button" type="button" class="btn btn-mini">' + this.lang.get('cancel') + '</button></li><li class="ccm-inline-toolbar-button ccm-inline-toolbar-button-save"><button id="ccm-redactor-save-button" type="button" class="btn btn-primary btn-mini">' + this.lang.get('save') + '</button></li>'));
             var toolbar = this.$toolbar;
 
             $('#ccm-redactor-cancel-button').unbind().on('click', function() {

--- a/web/concrete/js/build/core/redactor/magic.js
+++ b/web/concrete/js/build/core/redactor/magic.js
@@ -67,7 +67,7 @@ RedactorPlugins.concrete5magic = function() {
                         dropdown['s' + i] = { title: s.title, className:s.menuClass, func: function() { plugin.setCustomFormat(s); }};
                     });
 
-                    dropdown['remove'] = { title: ccmi18n_redactor.remove_style, func: function() { plugin.resetCustomFormat(); }};
+                    dropdown['remove'] = { title: that.lang.get('remove_style'), func: function() { plugin.resetCustomFormat(); }};
                     plugin.createButton(dropdown);
 
                 }

--- a/web/concrete/js/build/core/redactor/specialcharacters.js
+++ b/web/concrete/js/build/core/redactor/specialcharacters.js
@@ -279,7 +279,7 @@ RedactorPlugins.specialcharacters = function()
         ]
         ,
         init: function() {
-            var button = this.button.addAfter('horizontalrule', 'special-character-button', 'Insert Character');
+            var button = this.button.addAfter('horizontalrule', 'special-character-button', this.lang.get('insert_character'));
             this.button.setAwesome('special-character-button', 'fa-copyright');
             this.button.addCallback(button, this.specialcharacters.show);
         },
@@ -300,7 +300,7 @@ RedactorPlugins.specialcharacters = function()
         show: function()
         {
             this.modal.addTemplate('specialcharacters', this.specialcharacters.getTemplate());
-            this.modal.load('specialcharacters', 'Insert Character', 500);
+            this.modal.load('specialcharacters', this.lang.get('insert_character'), 500);
             this.modal.createCancelButton();
             this.selection.save();
             this.modal.show();

--- a/web/concrete/js/build/core/redactor/underline.js
+++ b/web/concrete/js/build/core/redactor/underline.js
@@ -4,7 +4,7 @@ RedactorPlugins.underline = function() {
 	return {
 		init: function()
 		{
-			this.button.addAfter('italic', 'underline', 'Underline');
+			this.button.addAfter('italic', 'underline', this.lang.get('underline'));
 			/* concrete5 */
 			$btn = this.button.get('underline');
 			this.button.addCallback($btn, this.underline.format);

--- a/web/concrete/js/build/core/redactor/undoredo.js
+++ b/web/concrete/js/build/core/redactor/undoredo.js
@@ -6,8 +6,8 @@ RedactorPlugins.undoredo = function() {
     return {
         init: function()
         {
-            var undo = this.button.addFirst('undo', 'Undo');
-            var redo = this.button.addAfter('undo', 'redo', 'Redo');
+            var undo = this.button.addFirst('undo', this.lang.get('undo'));
+            var redo = this.button.addAfter('undo', 'redo', this.lang.get('redo'));
             this.button.setAwesome('undo', 'fa-undo');
             this.button.setAwesome('redo', 'fa-undo fa-flip-horizontal');
 

--- a/web/concrete/js/build/vendor/redactor/redactor.js
+++ b/web/concrete/js/build/vendor/redactor/redactor.js
@@ -346,8 +346,8 @@
 				change_font_size: 'Change font size',
 				remove_style: 'Remove Style',
 				insert_character: 'Insert Character',
-			  undo: 'Undo',
-			  redo: 'Redo',
+				undo: 'Undo',
+				redo: 'Redo',
 				// Remember to add new strings also in in /concrete/controllers/frontend/assets_localization.php, function getRedactorJavascript
 				/* end concrete5 */
 				underline: 'Underline',

--- a/web/concrete/js/build/vendor/redactor/redactor.js
+++ b/web/concrete/js/build/vendor/redactor/redactor.js
@@ -339,15 +339,22 @@
 				lightbox_link_type_iframe_options: 'Frame Options',
 				lightbox_link_type_iframe_width: 'Width',
 				lightbox_link_type_iframe_height: 'Height',
+				customStyles: 'Custom Styles',
+				remove_font: 'Remove font',
+				change_font_family: 'Change font family',
+				remove_font_size: 'Remove font size',
+				change_font_size: 'Change font size',
+				remove_style: 'Remove Style',
+				insert_character: 'Insert Character',
+			  undo: 'Undo',
+			  redo: 'Redo',
+				// Remember to add new strings also in in /concrete/controllers/frontend/assets_localization.php, function getRedactorJavascript
 				/* end concrete5 */
 				underline: 'Underline',
 				alignment: 'Alignment',
 				filename: 'Name (optional)',
 				edit: 'Edit',
 				upload_label: 'Drop file here or '
-				/* concrete5 */
-				// Remember to add new strings also in in /concrete/controllers/frontend/assets_localization.php, function getRedactorJavascript
-				/* end concrete5 */
 			}
 		}
 	};


### PR DESCRIPTION
- Get rid of `ccmi18n_redactor` global JS var and use Redactor `lang.get` method
- Synchronize vendor's `redactor.js` and `assets_localization.php`
- Translate `specialcharacters` plugin
- Translate `underline` plugin
- Translate `undoredo` plugin