### PR TITLE
Register package autoloader on install

### DIFF
--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -21,6 +21,7 @@ use Concrete\Core\Feature\Category\Category as FeatureCategory;
 use Concrete\Core\Feature\Feature;
 use Concrete\Core\File\FileList;
 use Concrete\Core\File\StorageLocation\Type\Type as StorageLocation;
+use Concrete\Core\Foundation\ClassLoader;
 use Concrete\Core\Foundation\Object;
 use Concrete\Core\Gathering\DataSource\DataSource as GatheringDataSource;
 use Concrete\Core\Gathering\Item\Template\Template as GatheringItemTemplate;
@@ -994,7 +995,8 @@ class Package extends Object
             "INSERT INTO Packages (pkgName, pkgDescription, pkgVersion, pkgHandle, pkgIsInstalled, pkgDateInstalled) VALUES (?, ?, ?, ?, ?, ?)",
             $v);
 
-        $pkg = Package::getByID($db->Insert_ID());
+        $pkg = Package::getByID($db->lastInsertId());
+        ClassLoader::getInstance()->registerPackage($pkg);
         $pkg->installDatabase();
 
         $env = Environment::get();


### PR DESCRIPTION
Fixes part of #2169.
When https://github.com/concrete5/concrete5-5.7.0/commit/9ffea260d06bab58f85cc21c8703d2f248e44630#diff-870da868c5b9a1d629e57609bae3758eR84 was removed packages may not install right if they try to load any classes in the package because package autoloaders are only registered for those installed at the start of the request. That line was hiding this bug.