### PR TITLE
Return the ID for storage locations

### DIFF
--- a/web/concrete/src/File/File.php
+++ b/web/concrete/src/File/File.php
@@ -538,7 +538,7 @@ class File implements \Concrete\Core\Permission\ObjectInterface
 
     /**
      * returns the most recent FileVersion object
-     * @return FileVersion
+     * @return Version
      */
     public function getRecentVersion()
     {

--- a/web/concrete/src/File/File.php
+++ b/web/concrete/src/File/File.php
@@ -129,7 +129,7 @@ class File implements \Concrete\Core\Permission\ObjectInterface
 
     public function getStorageLocationID()
     {
-        return $this->storageLocation;
+        return $this->getFileStorageLocationObject()->getID();
     }
 
     /**


### PR DESCRIPTION
For some reason in the getID function we were returning the object... and not the ID which broke some stuff so now it actually returns the ID of the storage location