### PR TITLE
Include empty files directory

### DIFF
--- a/web/application/files/.gitignore
+++ b/web/application/files/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/web/application/files/.gitignore
+++ b/web/application/files/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Is there a reason why this was removed? It is needed to install concrete5.