### PR TITLE
Fixes add block panel scrolling speed

### DIFF
--- a/web/concrete/js/build/core/app/edit-mode/editmode.js
+++ b/web/concrete/js/build/core/app/edit-mode/editmode.js
@@ -480,14 +480,14 @@
 
             $(element).find('.ccm-panel-content').mousewheel(function (e) {
 
-                if (!e.deltaY) {
+                if (!e.deltaY || !e.deltaFactor) {
                     return;
                 }
 
-                var change = -1 * e.deltaY;
+                var change = -1 * e.deltaY * e.deltaFactor;
 
                 var me = $(this),
-                    deltaY = e.originalEvent.deltaY || 0,
+                    deltaY = change || 0,
                     distance_from_top = me.scrollTop(),
                     distance_from_bottom = (me.get(0).scrollHeight - (me.scrollTop() + me.height()) - me.css('paddingTop').replace('px', ''));
 


### PR DESCRIPTION
This seemed to fix up issue #1668 for me. Tested it in chrome and firefox and both work well for me.