### PR TITLE
no translations in emergy exception

### DIFF
--- a/web/concrete/src/Error/Handler/ErrorHandler.php
+++ b/web/concrete/src/Error/Handler/ErrorHandler.php
@@ -52,8 +52,8 @@ class ErrorHandler extends PrettyPageHandler
                 if ($db->isConnected()) {
                     $l = new Logger(LOG_TYPE_EXCEPTIONS);
                     $l->emergency(
-                        t('Exception Occurred: ') . sprintf(
-                            "%s:%d %s (%d)\n",
+                        sprintf(
+                            "Exception Occurred: %s:%d %s (%d)\n",
                             $e->getFile(),
                             $e->getLine(),
                             $e->getMessage(),


### PR DESCRIPTION
I ran into some autoloading issues during which the translations weren't loaded yet.
I'd recommend to avoid using the t-function for internal / low-level exception.

If you really want to have them, at least make sure you don't use string concatenation as the order of the words can change depending on the language.