### PR TITLE
Use one style tag for custom styles

### DIFF
--- a/web/concrete/controllers/dialog/block/design.php
+++ b/web/concrete/controllers/dialog/block/design.php
@@ -94,6 +94,7 @@ class Design extends BackendInterfaceBlockController {
             $style = new CustomStyle($set, $b->getBlockID(), $this->area->getAreaHandle());
 
             $pr->setAdditionalDataAttribute('css', $style->getCSS());
+            $pr->setAdditionalDataAttribute('class', $style->getCustomStyleClass());
             $pr->setAdditionalDataAttribute('bID', $b->getBlockID());
             $pr->setMessage(t('Design updated.'));
             $pr->outputJSON();

--- a/web/concrete/js/build/core/style-customizer/inline-toolbar.js
+++ b/web/concrete/js/build/core/style-customizer/inline-toolbar.js
@@ -25,17 +25,22 @@
 
     ConcreteInlineStyleCustomizer.prototype = {
 
-        refreshStyles: function(resp) {
-            var stylesheets = document.styleSheets,
-                stylesheet = null,
-                ruleCount = 0;
+        getCollectionStyles: function() {
+            var stylesheets = document.styleSheets;
+
             for (var i = 0; i < stylesheets.length; i++) {
                 // is this the one we want?
                 if (stylesheets[i].ownerNode.id === 'collection-styles') {
-                    stylesheet = stylesheets[i];
-                    break;
+                    return stylesheets[i];
                 }
             }
+
+            return null;
+        },
+
+        refreshStyles: function(resp) {
+            var stylesheet = this.getCollectionStyles(),
+                ruleCount = 0;
 
             if (resp.oldIssID && stylesheet !== null) {
                 // grab the rules and remove the ones we don't want anymore
@@ -43,7 +48,6 @@
                 var removedCount = 0;
                 var regexp = new RegExp("\\." + resp.class.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') + "($|\\D)");
                 for (var ri = 0; ri < rules.length; ri++) {
-                    // this is getting strange...
                     if (regexp.test(rules[ri].selectorText)) {
                         // remove this style
                         stylesheet.deleteRule(ri - removedCount++);
@@ -54,6 +58,11 @@
 
             if (resp.issID) {
                 // now we need to add new styles
+                if (stylesheet === null) {
+                    var newStylesheet = $("<style id='collection-styles' />");
+                    $('head').append(newStylesheet);
+                    stylesheet = this.getCollectionStyles();
+                }
                 var newRules = resp.css.split("}");
                 for (var nri = 0; nri < newRules.length; nri++) {
                     var newRule = newRules[nri];

--- a/web/concrete/js/build/core/style-customizer/inline-toolbar.js
+++ b/web/concrete/js/build/core/style-customizer/inline-toolbar.js
@@ -30,7 +30,7 @@
 
             for (var i = 0; i < stylesheets.length; i++) {
                 // is this the one we want?
-                if (stylesheets[i].ownerNode.id === 'collection-styles') {
+                if (stylesheets[i].ownerNode.id === 'ccm-collection-styles') {
                     return stylesheets[i];
                 }
             }
@@ -59,7 +59,7 @@
             if (resp.issID) {
                 // now we need to add new styles
                 if (stylesheet === null) {
-                    var newStylesheet = $("<style id='collection-styles' />");
+                    var newStylesheet = $("<style id='ccm-collection-styles' />");
                     $('head').append(newStylesheet);
                     stylesheet = this.getCollectionStyles();
                 }

--- a/web/concrete/src/Block/CustomStyle.php
+++ b/web/concrete/src/Block/CustomStyle.php
@@ -112,4 +112,13 @@ class CustomStyle extends AbstractCustomStyle
         }
         return $class;
     }
+
+    public function getCustomStyleClass()
+    {
+        $class = 'ccm-custom-style-';
+        $txt = Core::make('helper/text');
+        $class .= strtolower($txt->filterNonAlphaNum($this->arHandle));
+        $class .= '-' . $this->bID;
+        return $class;
+    }
 }

--- a/web/concrete/src/Page/Collection/Collection.php
+++ b/web/concrete/src/Page/Collection/Collection.php
@@ -625,10 +625,11 @@ class Collection extends Object
             }
         }
 
-        $styleHeader = '';
+        $styleHeader = '<style type="text/css" id="collection-styles">';
         foreach ($psss as $st) {
-            $styleHeader .= '<style type="text/css" data-style-set="'.$st->getStyleSet()->getID().'">'.$st->getCSS().'</style>';
+            $styleHeader .= $st->getCSS();
         }
+        $styleHeader .= '</style>';
 
         if (strlen(trim($styleHeader))) {
             if ($return == true) {

--- a/web/concrete/src/Page/Collection/Collection.php
+++ b/web/concrete/src/Page/Collection/Collection.php
@@ -625,7 +625,7 @@ class Collection extends Object
             }
         }
 
-        $styleHeader = '<style type="text/css" id="collection-styles">';
+        $styleHeader = '<style type="text/css" id="ccm-collection-styles">';
         foreach ($psss as $st) {
             $styleHeader .= $st->getCSS();
         }


### PR DESCRIPTION
Helps with #2180. Instead of creating a style tag for every block I combine them all into one and then find & replace the rules.

This is still a WIP. I think this will work in all modern browsers but have only tested it in Firefox so far. Wanted to throw this out there so someone can stop me if its a terrible idea.