### PR TITLE
Remove wordwrap

### DIFF
--- a/web/concrete/css/build/vendor/select2/select2.less
+++ b/web/concrete/css/build/vendor/select2/select2.less
@@ -388,6 +388,8 @@ html[dir="rtl"] .select2-dropdown-open .select2-choice .select2-arrow b {
       cursor: pointer;
 
       min-height: 1em;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
 
       -webkit-touch-callout: none;
         -webkit-user-select: none;

--- a/web/concrete/elements/files/search.php
+++ b/web/concrete/elements/files/search.php
@@ -63,7 +63,7 @@ $req = $flr->getSearchRequest();
         <select multiple name="fsID[]" class="select2-select" style="width: 360px">
             <optgroup label="<?php echo t('Sets')?>">
             <?php foreach ($s1 as $s) { ?>
-                <option value="<?php echo $s->getFileSetID()?>"  <?php if (is_array($req['fsID']) && in_array($s->getFileSetID(), $req['fsID'])) { ?> selected="selected" <?php } ?>><?php echo wordwrap($s->getFileSetDisplayName(), '23', '&shy;', true)?></option>
+                <option value="<?php echo $s->getFileSetID()?>"  <?php if (is_array($req['fsID']) && in_array($s->getFileSetID(), $req['fsID'])) { ?> selected="selected" <?php } ?>><?php echo $s->getFileSetDisplayName()?></option>
             <?php } ?>
             </optgroup>
             <optgroup label="<?php echo t('Other')?>">


### PR DESCRIPTION
The `wordwrap()` function is not multibyte friendly. Let's remove it and use css instead.

![file_manager](https://cloud.githubusercontent.com/assets/514294/7129623/d79a4168-e29d-11e4-8bac-fc36e49af447.png)

![file_manager1](https://cloud.githubusercontent.com/assets/514294/7129622/d797e5ee-e29d-11e4-999b-36612ba652a9.png)