### PR TITLE
Avoid accessing an undefined variable in block_area_header/footer_view

### DIFF
--- a/web/concrete/elements/block_area_footer_view.php
+++ b/web/concrete/elements/block_area_footer_view.php
@@ -1,11 +1,13 @@
-<?
-defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 $c = Page::getCurrentPage();
 $css = $c->getAreaCustomStyle($a);
-if (is_object($css)) {
-    $class = $css->getContainerClass();
-}
 
-if ($class) { ?>
-</div>
-<? } ?>
+if (isset($css)) {
+    $class = $css->getContainerClass();
+} else {
+    $class = '';
+}
+if ($class !== '') {
+    ?></div><?php
+}

--- a/web/concrete/elements/block_area_header_view.php
+++ b/web/concrete/elements/block_area_header_view.php
@@ -1,11 +1,13 @@
-<?
-defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 $c = Page::getCurrentPage();
 $css = $c->getAreaCustomStyle($a);
-if (is_object($css)) {
-    $class = $css->getContainerClass();
-}
 
-if ($class) { ?>
-    <div class="<?=$class?>" >
-<? } ?>
+if (isset($css)) {
+    $class = $css->getContainerClass();
+} else {
+    $class = '';
+}
+if ($class !== '') {
+    ?><div class="<?=$class?>"><?php 
+}


### PR DESCRIPTION
Let's be sure to define `$class` before using it.
Furthermore: `getAreaCustomStyle()` returns `null` or an object, so let's use `isset` instead of `is_object` (much faster).