### PR TITLE
Improve default permissions of Drafts page

### DIFF
--- a/web/concrete/src/Package/StartingPointPackage.php
+++ b/web/concrete/src/Package/StartingPointPackage.php
@@ -9,6 +9,7 @@ use Concrete\Core\File\Image\Thumbnail\Type\Type;
 use Concrete\Core\Mail\Importer\MailImporter;
 use Concrete\Core\Permission\Access\Entity\ConversationMessageAuthorEntity;
 use Concrete\Core\Permission\Access\Entity\GroupEntity as GroupPermissionAccessEntity;
+use Concrete\Core\Permission\Access\Entity\PageOwnerEntity as PageOwnerPermissionAccessEntity;
 use Concrete\Core\Updater\Migrations\Configuration;
 use Concrete\Core\User\Point\Action\Action as UserPointAction;
 use Config;
@@ -465,6 +466,42 @@ class StartingPointPackage extends BasePackage
         // dashboard
         $dashboard = Page::getByPath('/dashboard', "RECENT");
         $dashboard->assignPermissions($g3, array('view_page'));
+
+        // drafts
+        $drafts = Page::getByPath('/!drafts', "RECENT");
+        $drafts->assignPermissions($g1, array('view_page'));
+        $drafts->assignPermissions(
+            $g3,
+            array(
+                'view_page_versions',
+                'view_page_in_sitemap',
+                'preview_page_as_user',
+                'edit_page_properties',
+                'edit_page_contents',
+                'edit_page_speed_settings',
+                'edit_page_theme',
+                'edit_page_template',
+                'edit_page_permissions',
+                'delete_page',
+                'delete_page_versions',
+                'approve_page_versions',
+                'add_subpage',
+                'move_or_copy_page',
+                'schedule_page_contents_guest_access'
+            )
+        );
+        $drafts->assignPermissions(
+            PageOwnerPermissionAccessEntity::getOrCreate(),
+            array(
+                'view_page_versions',
+                'edit_page_properties',
+                'edit_page_contents',
+                'edit_page_template',
+                'delete_page',
+                'delete_page_versions',
+                'approve_page_versions'
+            )
+        );
 
         $config = \Core::make('config/database');
         $config->save('concrete.security.token.jobs', Loader::helper('validation/identifier')->getString(64));

--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -25,6 +25,7 @@ use PageTheme;
 use Concrete\Core\Permission\Key\PageKey as PagePermissionKey;
 use PermissionAccess;
 use Concrete\Core\Package\PackageList;
+use Concrete\Core\Permission\Access\Entity\Entity as PermissionAccessEntity;
 use Concrete\Core\Permission\Access\Entity\GroupEntity as GroupPermissionAccessEntity;
 use Concrete\Core\Permission\Access\Entity\GroupCombinationEntity as GroupCombinationPermissionAccessEntity;
 use Concrete\Core\Permission\Access\Entity\UserEntity as UserPermissionAccessEntity;
@@ -510,6 +511,8 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             // group combination
         } elseif ($userOrGroup instanceof User || $userOrGroup instanceof UserInfo) {
             $pe = UserPermissionAccessEntity::getOrCreate($userOrGroup);
+        } elseif ($userOrGroup instanceof PermissionAccessEntity) {
+            $pe = $userOrGroup;
         } else {
             // group;
             $pe = GroupPermissionAccessEntity::getOrCreate($userOrGroup);


### PR DESCRIPTION
Draft pages inherits their permissions from their parent page (usually it is Home page). When we want to create a limited user account that will be allowed to create some types of page, we have to change the permissions of Draft (/!drafts) page. If not, the limited user will get weird "Not Found" page when creating a new draft page, because the user can't access to editing permissions of "Home" page. It is not intuitive. This change helps people who wants to setup Advanced Permission mode.

1. `/!drafts` page should have own permissions, not inherit from Home page
2. Assign "Page Owner" to some permissions that are required to access to Composer interface
3. A new draft page inherits its permissions from `/!drafts` page.