### PR TITLE
Ensure maps blocks have a unique identity

### DIFF
--- a/web/concrete/blocks/google_map/controller.php
+++ b/web/concrete/blocks/google_map/controller.php
@@ -3,6 +3,7 @@ namespace Concrete\Block\GoogleMap;
 use Loader;
 use Page;
 use \Concrete\Core\Block\BlockController;
+use Core;
 class Controller extends BlockController {
 	
 	protected $btTable = 'btGoogleMap';
@@ -54,27 +55,14 @@ class Controller extends BlockController {
     }
 
 	public function view(){
-		$this->set('unique_identifier', $this->get_unique_identifier());
+		$this->set('unique_identifier', Core::make('helper/validation/identifier')->getString(18));
 		$this->set('title', $this->title);
 		$this->set('location', $this->location);
 		$this->set('latitude', $this->latitude);
 		$this->set('longitude', $this->longitude);
 		$this->set('zoom', $this->zoom);			
 	}
-	public function get_unique_identifier()
-	{	
-		// This is needed because blocks in stacks don't have a proxy, but still need to be unique
-		$suffix = '_'.rand(0,1000000);
 
-		// its a copy, so use proxy id
-		if($this->getBlockObject()->getProxyBlock()){
-			return $this->getBlockObject()->getProxyBlock()->getInstance()->getIdentifier().$suffix;
-		}
-
-		// its a unique block, so use id
-		return $this->getIdentifier().$suffix;
-	}
-	
 	public function save($data) { 
 		$args['title'] = isset($data['title']) ? trim($data['title']) : '';
 		$args['location'] = isset($data['location']) ? trim($data['location']) : '';

--- a/web/concrete/blocks/google_map/controller.php
+++ b/web/concrete/blocks/google_map/controller.php
@@ -54,12 +54,25 @@ class Controller extends BlockController {
     }
 
 	public function view(){
-		$this->set('bID', $this->bID);
+		$this->set('unique_identifier', $this->get_unique_identifier());
 		$this->set('title', $this->title);
 		$this->set('location', $this->location);
 		$this->set('latitude', $this->latitude);
 		$this->set('longitude', $this->longitude);
 		$this->set('zoom', $this->zoom);			
+	}
+	public function get_unique_identifier()
+	{	
+		// This is needed because blocks in stacks don't have a proxy, but still need to be unique
+		$suffix = '_'.rand(0,1000000);
+
+		// its a copy, so use proxy id
+		if($this->getBlockObject()->getProxyBlock()){
+			return $this->getBlockObject()->getProxyBlock()->getInstance()->getIdentifier().$suffix;
+		}
+
+		// its a unique block, so use id
+		return $this->getIdentifier().$suffix;
 	}
 	
 	public function save($data) { 

--- a/web/concrete/blocks/google_map/view.php
+++ b/web/concrete/blocks/google_map/view.php
@@ -20,7 +20,7 @@ if ($c->isEditMode()) { ?>
 ?>
 
 <script type="text/javascript">
-    function googleMapInit<?=$bID?>() {
+    function googleMapInit<?=$unique_identifier?>() {
         try{
             var latlng = new google.maps.LatLng(<?=$latitude?>, <?=$longitude?>);
             var mapOptions = {
@@ -30,20 +30,20 @@ if ($c->isEditMode()) { ?>
                 streetViewControl: false,
                 mapTypeControl: false
             };
-            var map = new google.maps.Map(document.getElementById('googleMapCanvas<?=$bID?>'), mapOptions);
+            var map = new google.maps.Map(document.getElementById('googleMapCanvas<?=$unique_identifier?>'), mapOptions);
             var marker = new google.maps.Marker({
                 position: latlng,
                 map: map
             });
         }catch(e){
-            $("#googleMapCanvas<?=$bID?>").replaceWith("<p>Unable to display map: "+e.message+"</p>")}
+            $("#googleMapCanvas<?=$unique_identifier?>").replaceWith("<p>Unable to display map: "+e.message+"</p>")}
     }
     $(function() {
         var t;
         var startWhenVisible = function (){
-            if ($("#googleMapCanvas<?=$bID?>").is(":visible")){
+            if ($("#googleMapCanvas<?=$unique_identifier?>").is(":visible")){
                 window.clearInterval(t);
-                googleMapInit<?=$bID?>();
+                googleMapInit<?=$unique_identifier?>();
                 return true;
             }
             return false;


### PR DESCRIPTION
I was having issues with maps blocks not having a unique id and hence duplicate blocks failing to render. I started by using proxy block id's, but that continued to give duplicate id's if a map was in a stack pulled more than once.

This solution just makes sure the id's really are unique. It could still fail if the view of a stack is cached and used in more than one place on a page.

A better solution would be a complete refactoring of the way maps blocks create and interact with their JavaScript to avoid dependence on a block ID.