### PR TITLE
Fix warning in AssetList::getAsset:

### DIFF
--- a/web/concrete/src/Asset/AssetList.php
+++ b/web/concrete/src/Asset/AssetList.php
@@ -134,7 +134,7 @@ class AssetList
      */
     public function getAsset($assetType, $assetHandle)
     {
-        return $this->assets[$assetType][$assetHandle];
+        return isset($this->assets[$assetType][$assetHandle]) ? $this->assets[$assetType][$assetHandle] : null;
     }
 
     /**


### PR DESCRIPTION
When a theme controller calls something like `$this->providesAsset('css', 'bootstrap/*')` we try to access an asset that's not in the list.