### PR TITLE
Add classes to fieldset to enable targetting

### DIFF
--- a/web/concrete/attributes/address/form.php
+++ b/web/concrete/attributes/address/form.php
@@ -2,7 +2,7 @@
 <? $f = Loader::helper('form'); ?>
 <? $co = Loader::helper('lists/countries'); ?>
 
-<fieldset class="ccm-attribute-address-<?=$key->getAttributeKeyID()?>">
+<fieldset class="ccm-attribute ccm-attribute-address ccm-attribute-address-<?=$key->getAttributeKeyID()?>">
 <div class="ccm-attribute-address-line form-group">
     <?=$f->label($this->field('address1'), t('Address 1'))?>
     <?=$f->text($this->field('address1'), $address1)?>

--- a/web/concrete/attributes/address/type_form.php
+++ b/web/concrete/attributes/address/type_form.php
@@ -13,7 +13,7 @@ if (isset($_POST['akHasCustomCountries'])) {
 
 ?>
 
-<fieldset>
+<fieldset class="ccm-attribute ccm-attribute-address">
 <legend><?=t('Address Options')?></legend>
 
 <div class="form-group">

--- a/web/concrete/attributes/boolean/controller.php
+++ b/web/concrete/attributes/boolean/controller.php
@@ -83,13 +83,13 @@ class Controller extends AttributeTypeController  {
 	}
 	
 	public function composer() {
-		print '<div class="checkbox"><label>';
+		print '<div class="ccm-attribute ccm-attribute-boolean checkbox"><label>';
 		$this->form();
 		print '</label></div>';
 	}
 	
 	public function search() {
-		print '<div class="checkbox"><label>' . Loader::helper('form')->checkbox($this->field('value'), 1, $this->request('value') == 1) . ' ' . $this->attributeKey->getAttributeKeyDisplayName() . '</label></div>';
+		print '<div class="ccm-attribute ccm-attribute-boolean checkbox"><label>' . Loader::helper('form')->checkbox($this->field('value'), 1, $this->request('value') == 1) . ' ' . $this->attributeKey->getAttributeKeyDisplayName() . '</label></div>';
 	}
 
 	public function type_form() {

--- a/web/concrete/attributes/date_time/type_form.php
+++ b/web/concrete/attributes/date_time/type_form.php
@@ -1,4 +1,4 @@
-<fieldset>
+<fieldset class="ccm-attribute ccm-attribute-date-time">
 <legend><?=t('Date/Time Options')?></legend>
 
 <div class="clearfix">

--- a/web/concrete/attributes/image_file/controller.php
+++ b/web/concrete/attributes/image_file/controller.php
@@ -87,7 +87,10 @@ class Controller extends AttributeTypeController
             $bf = $this->getValue();
         }
         $al = Loader::helper('concrete/asset_library');
-        print $al->file('ccm-file-akID-' . $this->attributeKey->getAttributeKeyID(), $this->field('value'), t('Choose File'), $bf);
+        $form = '<div class="ccm-attribute ccm-attribute-image-file">';
+        $form .= $al->file('ccm-file-akID-' . $this->attributeKey->getAttributeKeyID(), $this->field('value'), t('Choose File'), $bf);
+        $form .= '</div>';
+        print $form;
     }
 
     // run when we call setAttribute(), instead of saving through the UI

--- a/web/concrete/attributes/rating/service.php
+++ b/web/concrete/attributes/rating/service.php
@@ -49,7 +49,7 @@ class Service
         if ($value > 94) {
             $star5 = 'fa-star';
         }
-        $html .= '<div class="ccm-rating">';
+        $html .= '<div class="ccm-attribute ccm-attribute-rating ccm-rating">';
         $html .= '<div class="fa ' . $star1 . '"><a href="javascript:void(0)"></a></div>';
         $html .= '<div class="fa ' . $star2 . '"><a href="javascript:void(0)"></a></div>';
         $html .= '<div class="fa ' . $star3 . '"><a href="javascript:void(0)"></a></div>';
@@ -72,7 +72,7 @@ class Service
         }
 
         $sanitized = preg_replace('/[^A-Za-z0-9]/i', '', $field);
-        $html = '<div class="ccm-rating" data-rating-field-name="' . $sanitized . '" data-score="' . $value . '"></div>';
+        $html = '<div class="ccm-attribute ccm-attribute-rating ccm-rating" data-rating-field-name="' . $sanitized . '" data-score="' . $value . '"></div>';
         $html .= "<script type=\"text/javascript\">
             $(function() {
                 $('div[data-rating-field-name={$sanitized}]').awesomeStarRating({

--- a/web/concrete/attributes/select/form.php
+++ b/web/concrete/attributes/select/form.php
@@ -35,7 +35,7 @@ if ($akSelectAllowMultipleValues && $akSelectAllowOtherValues) { // display auto
 		}
 	</style>
 
-<div class="ccm-attribute-type-select-autocomplete">
+<div class="ccm-attribute ccm-attribute-select ccm-attribute-type-select-autocomplete">
 
 	<div id="selectedAttrValueRows_<?php echo $attrKeyID;?>" class="well well-small clearfix">
 		<h6><?=t('Selected Options')?></h6>

--- a/web/concrete/attributes/select/type_form.php
+++ b/web/concrete/attributes/select/type_form.php
@@ -38,7 +38,7 @@ function getAttributeOptionHTML($v){
 		<div class="ccm-spacer">&nbsp;</div>
 <? } ?>
 
-<fieldset>
+<fieldset class="ccm-attribute ccm-attribute-select">
 <legend><?=t('Select Options')?></legend>
 
 <div class="form-group">


### PR DESCRIPTION
Added classes "ccm-attribute" and "ccm-attribute-address" to the <fieldset> in order to enable targetting by CSS and jQuery. These two classes have been added preceding the already existing ID-based class which is (generally) unique unless there are multiple instances of the given attribute. Thus the classes are ordered by level of precision. 

See the related issue: https://github.com/concrete5/concrete5-5.7.0/issues/2262