### PR TITLE
Get rid of Loader in UserList

### DIFF
--- a/web/concrete/src/Legacy/UserList.php
+++ b/web/concrete/src/Legacy/UserList.php
@@ -3,7 +3,8 @@ namespace Concrete\Core\Legacy;
 use \Concrete\Core\Legacy\DatabaseItemList;
 use UserAttributeKey;
 use UserInfo;
-use Loader;
+use Core;
+use Database;
 use Group;
 /**
  * An object that allows a filtered list of users to be returned.
@@ -32,7 +33,7 @@ class UserList extends DatabaseItemList {
 	}
 
 	public function filterByKeywords($keywords) {
-		$db = Loader::db();
+		$db = Database::connection();
 		$qkeywords = $db->quote('%' . $keywords . '%');
 		$keys = UserAttributeKey::getSearchableIndexedList();
 		$emailSearchStr=' OR u.uEmail like '.$qkeywords.' ';
@@ -73,7 +74,7 @@ class UserList extends DatabaseItemList {
 	}
 
 	public function filterByGroupID($gID){
-		if (!Loader::helper('validation/numbers')->integer($gID)) {
+		if (!Core::make('helper/validation/numbers')->integer($gID)) {
 			$gID = 0;
 		}
 		$tbl='ug_'.$gID;
@@ -143,7 +144,7 @@ class UserList extends DatabaseItemList {
 	/* magic method for filtering by page attributes. */
 	public function __call($nm, $a) {
 		if (substr($nm, 0, 8) == 'filterBy') {
-			$txt = Loader::helper('text');
+			$txt = Core::make('helper/text');
 			$attrib = $txt->uncamelcase(substr($nm, 8));
 			if (count($a) == 2) {
 				$this->filterByAttribute($attrib, $a[0], $a[1]);

--- a/web/concrete/src/Legacy/UserList.php
+++ b/web/concrete/src/Legacy/UserList.php
@@ -1,11 +1,14 @@
 <?php
+
 namespace Concrete\Core\Legacy;
-use \Concrete\Core\Legacy\DatabaseItemList;
+
+use Concrete\Core\Legacy\DatabaseItemList;
 use UserAttributeKey;
 use UserInfo;
 use Core;
 use Database;
 use Group;
+
 /**
  * An object that allows a filtered list of users to be returned.
  * @package Files
@@ -13,145 +16,164 @@ use Group;
  * @category Concrete
  * @copyright  Copyright (c) 2003-2008 Concrete5. (http://www.concrete5.org)
  * @license    http://www.concrete5.org/license/     MIT License
- *
  */
+class UserList extends DatabaseItemList
+{
+    protected $attributeFilters = array();
+    protected $autoSortColumns = array('uName', 'uEmail', 'uDateAdded', 'uLastLogin', 'uNumLogins', 'uLastOnline');
+    protected $itemsPerPage = 10;
+    protected $attributeClass = 'UserAttributeKey';
 
-class UserList extends DatabaseItemList {
+    public $showInactiveUsers;
+    public $showInvalidatedUsers = 0;
+    public $searchAgainstEmail = 0;
 
-	protected $attributeFilters = array();
-	protected $autoSortColumns = array('uName', 'uEmail', 'uDateAdded', 'uLastLogin', 'uNumLogins', 'uLastOnline');
-	protected $itemsPerPage = 10;
-	protected $attributeClass = 'UserAttributeKey';
+    //Filter by uName
+    public function filterByUserName($username)
+    {
+        $this->filter('u.uName', $username, '=');
+    }
 
-	public $showInactiveUsers;
-	public $showInvalidatedUsers=0;
-	public $searchAgainstEmail=0;
+    public function filterByKeywords($keywords)
+    {
+        $db = Database::connection();
+        $qkeywords = $db->quote('%' . $keywords . '%');
+        $keys = UserAttributeKey::getSearchableIndexedList();
+        $emailSearchStr = ' OR u.uEmail like '.$qkeywords.' ';
+        $attribsStr = '';
+        foreach ($keys as $ak) {
+            $cnt = $ak->getController();
+            $attribsStr .= ' OR ' . $cnt->searchKeywords($keywords);
+        }
+        $this->filter(false, '( u.uName like ' . $qkeywords . $emailSearchStr . $attribsStr . ')');
+    }
 
-	//Filter by uName
-	public function filterByUserName($username) {
-		$this->filter('u.uName', $username, '=');
-	}
+    /**
+     * Filters the user list for only users within the provided group.  Accepts an instance of a group object or a string group name.
+     *
+     * @param Group|string $group
+     * @param bool $inGroup
+     */
+    public function filterByGroup($group = '', $inGroup = true)
+    {
+        if (!$group instanceof Group) {
+            $group = Group::getByName($group);
+        }
+        $tbl = 'ug_'.$group->getGroupID();
+        $this->addToQuery("left join UserGroups $tbl on {$tbl}.uID = u.uID ");
+        if ($inGroup) {
+            $this->filter(false, "{$tbl}.gID=".intval($group->getGroupID()));
+        } else {
+            $this->filter(false, "{$tbl}.gID is null");
+        }
+    }
 
-	public function filterByKeywords($keywords) {
-		$db = Database::connection();
-		$qkeywords = $db->quote('%' . $keywords . '%');
-		$keys = UserAttributeKey::getSearchableIndexedList();
-		$emailSearchStr=' OR u.uEmail like '.$qkeywords.' ';
-		$attribsStr = '';
-		foreach ($keys as $ak) {
-			$cnt = $ak->getController();
-			$attribsStr.=' OR ' . $cnt->searchKeywords($keywords);
-		}
-		$this->filter(false, '( u.uName like ' . $qkeywords . $emailSearchStr . $attribsStr . ')');
-	}
+    public function excludeUsers($uo)
+    {
+        if (is_object($uo)) {
+            $uID = $uo->getUserID();
+        } else {
+            $uID = $uo;
+        }
+        $this->filter('u.uID', $uID, '!=');
+    }
 
-	/**
-	 * filters the user list for only users within the provided group.  Accepts an instance of a group object or a string group name
-	 * @param Group|string $group
-	 * @param boolean $inGroup
-	 * @return void
-	*/
-	public function filterByGroup($group='', $inGroup = true){
-		if(!$group instanceof Group) {
-			$group = Group::getByName($group);
-		}
-		$tbl='ug_'.$group->getGroupID();
-		$this->addToQuery("left join UserGroups $tbl on {$tbl}.uID = u.uID ");
-		if ($inGroup) {
-			$this->filter(false, "{$tbl}.gID=".intval($group->getGroupID()) );
-		} else {
-			$this->filter(false, "{$tbl}.gID is null");
-		}
-	}
+    public function filterByGroupID($gID)
+    {
+        if (!Core::make('helper/validation/numbers')->integer($gID)) {
+            $gID = 0;
+        }
+        $tbl = 'ug_'.$gID;
+        $this->addToQuery("left join UserGroups $tbl on {$tbl}.uID = u.uID ");
+        $this->filter(false, "{$tbl}.gID=".$gID);
+    }
 
-	public function excludeUsers($uo) {
-		if (is_object($uo)) {
-			$uID = $uo->getUserID();
-		} else {
-			$uID = $uo;
-		}
-		$this->filter('u.uID',$uID,'!=');
-	}
+    public function filterByDateAdded($date, $comparison = '=')
+    {
+        $this->filter('u.uDateAdded', $date, $comparison);
+    }
 
-	public function filterByGroupID($gID){
-		if (!Core::make('helper/validation/numbers')->integer($gID)) {
-			$gID = 0;
-		}
-		$tbl='ug_'.$gID;
-		$this->addToQuery("left join UserGroups $tbl on {$tbl}.uID = u.uID ");
-		$this->filter(false, "{$tbl}.gID=".$gID);
-	}
+    /**
+     * Returns an array of userInfo objects based on current filter settings.
+     *
+     * @return UserInfo[]
+     */
+    public function get($itemsToGet = 100, $offset = 0)
+    {
+        $userInfos = array();
+        $this->createQuery();
+        $r = parent::get($itemsToGet, intval($offset));
+        foreach ($r as $row) {
+            $ui = UserInfo::getByID($row['uID']);
+            $userInfos[] = $ui;
+        }
 
-	public function filterByDateAdded($date, $comparison = '=') {
-		$this->filter('u.uDateAdded', $date, $comparison);
-	}
+        return $userInfos;
+    }
 
-	/**
-	 * Returns an array of userInfo objects based on current filter settings
-	 * @return UserInfo[]
-	 */
-	public function get($itemsToGet = 100, $offset = 0) {
-		$userInfos = array();
-		$this->createQuery();
-		$r = parent::get( $itemsToGet, intval($offset));
-		foreach($r as $row) {
-			$ui = UserInfo::getByID($row['uID']);
-			$userInfos[] = $ui;
-		}
-		return $userInfos;
-	}
+    /**
+     * Similar to get except it returns an array of userIDs.
+     * Much faster than getting a UserInfo object for each result if all you need is the user's id.
+     *
+     * @return array $userIDs
+     */
+    public function getUserIDs($itemsToGet = 100, $offset = 0)
+    {
+        $this->createQuery();
+        $userIDs = array();
+        $r = parent::get($itemsToGet, intval($offset));
+        foreach ($r as $row) {
+            $userIDs[] = $row['uID'];
+        }
 
-	/**
-	 * similar to get except it returns an array of userIDs
-	 * much faster than getting a UserInfo object for each result if all you need is the user's id
-	 * @return array $userIDs
-	*/
-	public function getUserIDs($itemsToGet = 100, $offset=0) {
-		$this->createQuery();
-		$userIDs = array();
-		$r = parent::get($itemsToGet, intval($offset));
-		foreach($r as $row) {
-			$userIDs[] = $row['uID'];
-		}
-		return $userIDs;
-	}
+        return $userIDs;
+    }
 
-	public function getTotal(){
-		$this->createQuery();
-		return parent::getTotal();
-	}
+    public function getTotal()
+    {
+        $this->createQuery();
 
-	public function filterByIsActive($val) {
-		$this->showInactiveUsers = $val;
-		$this->filter('u.uIsActive', $val);
-	}
+        return parent::getTotal();
+    }
 
-	//this was added because calling both getTotal() and get() was duplicating some of the query components
-	protected function createQuery(){
-		if(!$this->queryCreated){
-			$this->setBaseQuery();
-			if(!isset($this->showInactiveUsers)) $this->filter('u.uIsActive', 1);
-			if(!$this->showInvalidatedUsers) $this->filter('u.uIsValidated', 0, '!=');
-			$this->setupAttributeFilters("left join UserSearchIndexAttributes on (UserSearchIndexAttributes.uID = u.uID)");
-			$this->queryCreated=1;
-		}
-	}
+    public function filterByIsActive($val)
+    {
+        $this->showInactiveUsers = $val;
+        $this->filter('u.uIsActive', $val);
+    }
 
-	protected function setBaseQuery() {
-		$this->setQuery('SELECT DISTINCT u.uID, u.uName FROM Users u ');
-	}
+    //this was added because calling both getTotal() and get() was duplicating some of the query components
+    protected function createQuery()
+    {
+        if (!$this->queryCreated) {
+            $this->setBaseQuery();
+            if (!isset($this->showInactiveUsers)) {
+                $this->filter('u.uIsActive', 1);
+            }
+            if (!$this->showInvalidatedUsers) {
+                $this->filter('u.uIsValidated', 0, '!=');
+            }
+            $this->setupAttributeFilters("left join UserSearchIndexAttributes on (UserSearchIndexAttributes.uID = u.uID)");
+            $this->queryCreated = 1;
+        }
+    }
 
-	/* magic method for filtering by page attributes. */
-	public function __call($nm, $a) {
-		if (substr($nm, 0, 8) == 'filterBy') {
-			$txt = Core::make('helper/text');
-			$attrib = $txt->uncamelcase(substr($nm, 8));
-			if (count($a) == 2) {
-				$this->filterByAttribute($attrib, $a[0], $a[1]);
-			} else {
-				$this->filterByAttribute($attrib, $a[0]);
-			}
-		}
-	}
+    protected function setBaseQuery()
+    {
+        $this->setQuery('SELECT DISTINCT u.uID, u.uName FROM Users u ');
+    }
 
+    /* magic method for filtering by page attributes. */
+    public function __call($nm, $a)
+    {
+        if (substr($nm, 0, 8) == 'filterBy') {
+            $txt = Core::make('helper/text');
+            $attrib = $txt->uncamelcase(substr($nm, 8));
+            if (count($a) == 2) {
+                $this->filterByAttribute($attrib, $a[0], $a[1]);
+            } else {
+                $this->filterByAttribute($attrib, $a[0]);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Not sure why, but during the CLI install I have this error:
```
5%: Starting installation and creating directories.
10%: Creating database tables.
Whoops\Exception\ErrorException: Cannot use Loader as Loader because the name is already in use
    in file concrete/src/Legacy/UserList.php on line 6
Stack trace:
  1. () concrete/src/Legacy/UserList.php:6
   | array(0) {
   | }
```
I managed to get rid of this error by switching from `Loader::helper('...')` to `Core:make('helper/...')` and `Loader::db()` to `Database::connection()`