### PR TITLE
Fix warnings in addCollection

### DIFF
--- a/web/concrete/src/Page/Collection/Collection.php
+++ b/web/concrete/src/Page/Collection/Collection.php
@@ -83,6 +83,19 @@ class Collection extends Object
         $db = Loader::db();
         $dh = Loader::helper('date');
         $cDate = $dh->getOverridableNow();
+
+        $data = array_merge(
+            array(
+                'name' => '',
+                'pTemplateID' => 0,
+                'handle' => null,
+                'uID' => null,
+                'cDatePublic' => $cDate,
+                'cDescription' => null,
+            ),
+            $data
+        );
+
         $cDatePublic = ($data['cDatePublic']) ? $data['cDatePublic'] : $cDate;
 
         if (isset($data['cID'])) {
@@ -108,7 +121,7 @@ class Collection extends Object
             $cvIsNew = $data['cvIsNew'];
         }
         $data['name'] = Loader::helper('text')->sanitize($data['name']);
-        if (is_object($this) && $this instanceof Page) {
+        if (isset($this) && $this instanceof Page) {
             $pThemeID = $this->getCollectionThemeID();
         } else {
             $pThemeID = 0;


### PR DESCRIPTION
With this PR we'll have 561 less warnings during concrete5 installation with full sample content.