### PR TITLE
Avoid warnings in attribute value destructor

### DIFF
--- a/web/concrete/src/Attribute/Value/Value.php
+++ b/web/concrete/src/Attribute/Value/Value.php
@@ -34,8 +34,10 @@ class Value extends Object
 
     public function __destruct()
     {
-        if (is_object($this->attributeType)) {
-            $this->attributeType->__destruct();
+        if (isset($this->attributeType)) {
+            if (is_object($this->attributeType)) {
+                $this->attributeType->__destruct();
+            }
             unset($this->attributeType);
         }
     }


### PR DESCRIPTION
Another 415 less warnings during install with sample contents.
IMHO these warnings were caused by two calls to Value destructor: by child classes and by php.