### PR TITLE
Sort block types by displayOrder in add panel 

### DIFF
--- a/web/concrete/src/Block/BlockType/Set.php
+++ b/web/concrete/src/Block/BlockType/Set.php
@@ -192,7 +192,13 @@ class Set extends Object {
 		$r = $db->GetOne('select count(*) from BlockTypeSetBlockTypes where btsID = ? and btID = ?', array($this->getBlockTypeSetID(), $bt->getBlockTypeID()));
 		return $r > 0;
 	}
-
+	
+    public function displayOrder($bt) {
+        $db = Loader::db();
+        $r = $db->GetOne('select displayOrder from BlockTypeSetBlockTypes where btsID = ? and btID = ?', array($this->getBlockTypeSetID(), $bt->getBlockTypeID()));
+        return $r;
+    }
+    
 	public function delete() {
 		$db = Loader::db();
 		$db->Execute('delete from BlockTypeSets where btsID = ?', array($this->getBlockTypeSetID()));

--- a/web/concrete/views/panels/add.php
+++ b/web/concrete/views/panels/add.php
@@ -291,6 +291,9 @@ switch ($tab) {
                                 $blocktypes = array();
                             }
                             if (count($blocktypes)) {
+
+                                usort ( $blocktypes, function($bt_a, $bt_b) use($set){return ($set->displayOrder($bt_a) > $set->displayOrder($bt_b))?1:-1;});
+
                                 foreach ($blocktypes as $bt) {
 
                                     $btIcon = $ci->getBlockTypeIconURL($bt);


### PR DESCRIPTION
A better implementation of
https://github.com/concrete5/concrete5-5.7.0/pull/2256

Added a displayOrder method to Set class and used that in a usort within the Add panel