### PR TITLE
Use group name instead of display name in tree view

### DIFF
--- a/web/concrete/src/Tree/Node/Type/Group.php
+++ b/web/concrete/src/Tree/Node/Type/Group.php
@@ -94,6 +94,12 @@ class Group extends TreeNode
         if (is_object($obj)) {
             $obj->gID = $this->gID;
             $obj->iconClass = 'fa fa-users';
+            // If not root node...
+            if (isset($this->gID)) {
+                // ...use Name (not DisplayName,
+                // which contains full path).
+                $obj->title = $this->getTreeNodeName();
+	        }
 
             return $obj;
         }


### PR DESCRIPTION
Using a group's display name (which is basically its full path within the group hierarchy) in tree view seems redundant and increases screen clutter. Instead, use just the name of the group.