### PR TITLE
Show localized names in Groups tree, without parents path

### DIFF
--- a/web/concrete/src/Tree/Node/Type/Group.php
+++ b/web/concrete/src/Tree/Node/Type/Group.php
@@ -44,7 +44,7 @@ class Group extends TreeNode
 
         $g = UserGroup::getByID($this->gID);
         if (is_object($g)) {
-            $gName = $g->getGroupDisplayName(false);
+            $gName = $g->getGroupDisplayName(false, false);
             switch ($format) {
                 case 'html':
                     return h($gName);
@@ -94,7 +94,9 @@ class Group extends TreeNode
         if (is_object($obj)) {
             $obj->gID = $this->gID;
             $obj->iconClass = 'fa fa-users';
-
+            if (isset($this->gID)) {
+                $obj->title = $this->getTreeNodeDisplayName('text');
+            }
             return $obj;
         }
     }

--- a/web/concrete/src/User/Group/Group.php
+++ b/web/concrete/src/User/Group/Group.php
@@ -280,21 +280,23 @@ class Group extends Object implements \Concrete\Core\Permission\ObjectInterface
         }
     }
 
-    public function getGroupDisplayName($includeHTML = true)
+    public function getGroupDisplayName($includeHTML = true, $includePath = true)
     {
         $return = '';
-        $parentGroups = $this->getParentGroups();
-        if (count($parentGroups) > 0) {
-            if ($includeHTML) {
-                $return .= '<span class="ccm-group-breadcrumb">';
-            }
-            foreach ($parentGroups as $pg) {
-                $return .= h(tc('GroupName', $pg->getGroupName()));
-                $return .= ' ' . Config::get('concrete.seo.group_name_separator') . ' ';
-            }
-            $return = trim($return);
-            if ($includeHTML) {
-                $return .= '</span> ';
+        if ($includePath) {
+            $parentGroups = $this->getParentGroups();
+            if (count($parentGroups) > 0) {
+                if ($includeHTML) {
+                    $return .= '<span class="ccm-group-breadcrumb">';
+                }
+                foreach ($parentGroups as $pg) {
+                    $return .= h(tc('GroupName', $pg->getGroupName()));
+                    $return .= ' ' . Config::get('concrete.seo.group_name_separator') . ' ';
+                }
+                $return = trim($return);
+                if ($includeHTML) {
+                    $return .= '</span> ';
+                }
             }
         }
         $return .= tc('GroupName', $this->getGroupName());


### PR DESCRIPTION
This pull request improves (and supersedes) #2288 by translating group names