### PR TITLE
Fix guide background color

### DIFF
--- a/web/concrete/css/build/core/app/dialog.less
+++ b/web/concrete/css/build/core/app/dialog.less
@@ -40,7 +40,7 @@ div.ccm-dialog-slim {
   }
   div.col-accented {
     background-color: #e9e9e9;
-    height: 100%;
+    min-height: 100%;
   }
 
   div[class^="col-"] {


### PR DESCRIPTION
Turns this:
![bad-right-column](https://cloud.githubusercontent.com/assets/928116/7268790/3dd2dec4-e8cd-11e4-968c-d26840934b64.gif)

into this:
![good-right-column](https://cloud.githubusercontent.com/assets/928116/7268792/43fa5520-e8cd-11e4-80fe-230e30f6a9ed.gif)
