### PR TITLE
Improve IDE symbols file

### DIFF
--- a/build/libraries/generate-symbols.php
+++ b/build/libraries/generate-symbols.php
@@ -1,4 +1,7 @@
 <?php
+use Concrete\Core\Support\Symbol\ClassSymbol\ClassSymbol;
+use Concrete\Core\Support\Symbol\ClassSymbol\MethodSymbol\MethodSymbol;
+
 define('C5_ENVIRONMENT_ONLY', true);
 
 error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED);
@@ -14,8 +17,16 @@ $corePath = DIR_BASE . '/concrete';
 $cms = require_once $corePath . '/dispatcher.php';
 
 $generator = new \Concrete\Core\Support\Symbol\SymbolGenerator();
-
-$symbols = $generator->render();
+$symbols = $generator->render(
+    "\n",
+    '    ',
+    function (ClassSymbol $class, MethodSymbol $method) {
+        if ($class->isFacade()) {
+            return true;
+        }
+        return false;
+    }
+);
 file_put_contents(DIR_BASE . '/concrete/src/Support/__IDE_SYMBOLS__.php', $symbols);
 
 $metadataGenerator = new \Concrete\Core\Support\Symbol\MetadataGenerator();

--- a/build/libraries/generate-symbols.php
+++ b/build/libraries/generate-symbols.php
@@ -1,4 +1,5 @@
 <?php
+
 use Concrete\Core\Support\Symbol\ClassSymbol\ClassSymbol;
 use Concrete\Core\Support\Symbol\ClassSymbol\MethodSymbol\MethodSymbol;
 
@@ -7,10 +8,9 @@ define('C5_ENVIRONMENT_ONLY', true);
 error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED);
 ini_set('display_errors', 1);
 define('C5_EXECUTE', true);
-if(isset($argv) && is_array($argv) && isset($argv[1])) {
+if (isset($argv) && is_array($argv) && isset($argv[1])) {
     define('DIR_BASE', $argv[1]);
-}
-else {
+} else {
     define('DIR_BASE', dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'web');
 }
 $corePath = DIR_BASE . '/concrete';
@@ -24,6 +24,7 @@ $symbols = $generator->render(
         if ($class->isFacade()) {
             return true;
         }
+
         return false;
     }
 );
@@ -35,4 +36,3 @@ $meta = $metadataGenerator->render();
 file_put_contents(DIR_BASE . '/concrete/src/Support/.phpstorm.meta.php', $meta);
 
 die("Generation Complete.\n");
-

--- a/web/concrete/src/Support/Symbol/ClassSymbol/ClassSymbol.php
+++ b/web/concrete/src/Support/Symbol/ClassSymbol/ClassSymbol.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Support\Symbol\ClassSymbol;
 
 use Concrete\Core\Support\Symbol\ClassSymbol\MethodSymbol\MethodSymbol;
@@ -6,7 +7,6 @@ use ReflectionClass;
 
 class ClassSymbol
 {
-
     /**
      * Fully qualified class name.
      *
@@ -78,7 +78,7 @@ class ClassSymbol
     }
 
     /**
-     * Get the methods
+     * Get the methods.
      */
     protected function resolveMethods()
     {
@@ -89,7 +89,7 @@ class ClassSymbol
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isFacade()
     {
@@ -102,6 +102,7 @@ class ClassSymbol
      * @param string $eol
      * @param string $padding
      * @param callable|null $methodFilter
+     *
      * @return string
      */
     public function render($eol = "\n", $padding = '    ', $methodFilter = null)
@@ -131,6 +132,7 @@ class ClassSymbol
             }
         }
         $rendered .= "}{$eol}";
+
         return $rendered;
     }
 }

--- a/web/concrete/src/Support/Symbol/ClassSymbol/ClassSymbol.php
+++ b/web/concrete/src/Support/Symbol/ClassSymbol/ClassSymbol.php
@@ -57,12 +57,16 @@ class ClassSymbol
         $this->comment = $this->reflectionClass->getDocComment();
 
         if (
-            ($facade !== false)
-            &&
+            $facade === true
+            ||
             (
-                $this->reflectionClass->isSubclassOf('\Concrete\Core\Support\Facade\Facade')
-                ||
-                $this->reflectionClass->isSubclassOf('\Illuminate\Support\Facades\Facade')
+                $facade !== false
+                &&
+                (
+                    $this->reflectionClass->isSubclassOf('\Concrete\Core\Support\Facade\Facade')
+                    ||
+                    $this->reflectionClass->isSubclassOf('\Illuminate\Support\Facades\Facade')
+                )
             )
         ) {
             $obj = $fqn::getFacadeRoot();
@@ -112,13 +116,13 @@ class ClassSymbol
         if ($comment !== false) {
             $comment = trim($comment);
             if ($comment !== '') {
-                $rendered .= str_replace($eol.'*', $eol.' *', implode($eol, array_map('trim', explode("\n", $comment)))) . $eol;
+                $rendered .= str_replace($eol . '*', $eol . ' *', implode($eol, array_map('trim', explode("\n", $comment)))) . $eol;
             }
         }
         $rendered .= 'class ' . $this->alias . ' extends ' . $this->fqn . "{$eol}{{$eol}";
         $firstMethod = true;
         foreach ($this->methods as $method) {
-            if (isset($methodFilter) && (call_user_func($methodFilter, $this, $method) === false)) {
+            if (is_callable($methodFilter) && (call_user_func($methodFilter, $this, $method) === false)) {
                 continue;
             }
             if ($firstMethod) {

--- a/web/concrete/src/Support/Symbol/ClassSymbol/MethodSymbol/MethodSymbol.php
+++ b/web/concrete/src/Support/Symbol/ClassSymbol/MethodSymbol/MethodSymbol.php
@@ -55,19 +55,27 @@ class MethodSymbol
      * @param string $padding
      * @return string
      */
-    public function render($eol = PHP_EOL, $padding = '    ')
+    public function render($eol = "\n", $padding = '    ')
     {
         $method = $this->reflectionMethod;
         if ($method->isPrivate() || substr($method->getName(), 0, 2) === '__' || $method->isAbstract()) {
             return '';
         }
-        $rendered = $eol . implode($eol, array_map(trim, explode($eol, $method->getDocComment()))) . $eol;
+        $rendered = '';
+        $comment = $method->getDocComment();
+        if ($comment !== false) {
+            $comment = trim($comment);
+            if ($comment !== '') {
+                $rendered .= str_replace($eol.'*', $eol.' *', implode($eol, array_map('trim', explode("\n", $comment)))) . $eol;
+            }
+        }
         $visibility = \Reflection::getModifierNames($method->getModifiers());
-        if ($this->classSymbol->isFacade()) {
+        $isStatic = $method->isStatic();
+        if ((!$isStatic) && $this->classSymbol->isFacade()) {
+            $isStatic = true;
             $visibility[] = 'static';
         }
         $rendered .= implode(' ', array_unique($visibility)) . ' function ' . $this->handle . '(';
-
         $params = array();
         $calling_params = array();
         foreach ($this->parameters as $parameter) {
@@ -136,16 +144,16 @@ class MethodSymbol
         }
         $rendered .= implode(', ', $params) . "){$eol}{{$eol}";
         $class_name = $method->getDeclaringClass()->getName();
-        if ($method->isStatic()) {
-            $rendered .= "{$padding}return {$class_name}::{$method->getName()}(" . implode(
-                    ', ',
-                    $calling_params) . ");";
+        $rendered .= $padding.'return ';
+        if ($this->classSymbol->isFacade()) {
+            $rendered .= 'static::$instance->'.$method->getName();
+        } elseif ($isStatic) {
+            $rendered .= $class_name.'::'.$method->getName();
         } else {
-            $rendered .= "{$padding}/** @var {$class_name} \$instance */{$eol}";
-            $rendered .= "{$padding}return \$instance->{$method->getName()}(" . implode(', ', $calling_params) . ");";
+            $rendered .= 'parent::'.$method->getName();
         }
-
-        $rendered .= "{$eol}}{$eol}";
+        $rendered .= '(' . implode(', ', $calling_params) . ');'.$eol;
+        $rendered .= '}'.$eol;
 
         return $rendered;
     }

--- a/web/concrete/src/Support/Symbol/ClassSymbol/MethodSymbol/MethodSymbol.php
+++ b/web/concrete/src/Support/Symbol/ClassSymbol/MethodSymbol/MethodSymbol.php
@@ -67,7 +67,7 @@ class MethodSymbol
         if ($comment !== false) {
             $comment = trim($comment);
             if ($comment !== '') {
-                $rendered .= str_replace($eol.'*', $eol.' *', implode($eol, array_map('trim', explode("\n", $comment)))) . $eol;
+                $rendered .= str_replace($eol . '*', $eol . ' *', implode($eol, array_map('trim', explode("\n", $comment)))) . $eol;
             }
         }
         $visibility = \Reflection::getModifierNames($method->getModifiers());
@@ -145,16 +145,16 @@ class MethodSymbol
         }
         $rendered .= implode(', ', $params) . "){$eol}{{$eol}";
         $class_name = $method->getDeclaringClass()->getName();
-        $rendered .= $padding.'return ';
+        $rendered .= $padding . 'return ';
         if ($this->classSymbol->isFacade()) {
-            $rendered .= 'static::$instance->'.$method->getName();
+            $rendered .= 'static::$instance->' . $method->getName();
         } elseif ($isStatic) {
-            $rendered .= $class_name.'::'.$method->getName();
+            $rendered .= $class_name . '::' . $method->getName();
         } else {
-            $rendered .= 'parent::'.$method->getName();
+            $rendered .= 'parent::' . $method->getName();
         }
-        $rendered .= '(' . implode(', ', $calling_params) . ');'.$eol;
-        $rendered .= '}'.$eol;
+        $rendered .= '(' . implode(', ', $calling_params) . ');' . $eol;
+        $rendered .= '}' . $eol;
 
         return $rendered;
     }

--- a/web/concrete/src/Support/Symbol/ClassSymbol/MethodSymbol/MethodSymbol.php
+++ b/web/concrete/src/Support/Symbol/ClassSymbol/MethodSymbol/MethodSymbol.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace Concrete\Core\Support\Symbol\ClassSymbol\MethodSymbol;
 
 use Concrete\Core\Support\Symbol\ClassSymbol\ClassSymbol;
 
 class MethodSymbol
 {
-
     /**
      * @var \ReflectionMethod
      */
@@ -31,7 +31,7 @@ class MethodSymbol
     protected $parameters = array();
 
     /**
-     * The docblock
+     * The docblock.
      *
      * @var string
      */
@@ -49,10 +49,11 @@ class MethodSymbol
     }
 
     /**
-     * Render the Method
+     * Render the Method.
      *
      * @param string $eol
      * @param string $padding
+     *
      * @return string
      */
     public function render($eol = "\n", $padding = '    ')
@@ -86,15 +87,15 @@ class MethodSymbol
             } /*else if ($parameter->isCallable()) { // This should be enabled for php 5.4
                 $param .= 'callable ';
             } */ else {
-                try {
-                    if (is_object($parameter->getClass())) {
-                        $param .= $parameter->getClass()->getName() . ' ';
-                    }
-                } catch (\ReflectionException $e) {
-                    $class = $this->reflectionMethod->getDeclaringClass()->getName();
-                    echo "Invalid type hint in {$class}::{$this->handle}\n";
-                }
-            }
+     try {
+         if (is_object($parameter->getClass())) {
+             $param .= $parameter->getClass()->getName() . ' ';
+         }
+     } catch (\ReflectionException $e) {
+         $class = $this->reflectionMethod->getDeclaringClass()->getName();
+         echo "Invalid type hint in {$class}::{$this->handle}\n";
+     }
+ }
             if ($parameter->isPassedByReference()) {
                 $param .= "&";
             }
@@ -157,5 +158,4 @@ class MethodSymbol
 
         return $rendered;
     }
-
 }

--- a/web/concrete/src/Support/Symbol/ClassSymbol/MethodSymbol/MethodSymbol.php
+++ b/web/concrete/src/Support/Symbol/ClassSymbol/MethodSymbol/MethodSymbol.php
@@ -73,7 +73,6 @@ class MethodSymbol
         $visibility = \Reflection::getModifierNames($method->getModifiers());
         $isStatic = $method->isStatic();
         if ((!$isStatic) && $this->classSymbol->isFacade()) {
-            $isStatic = true;
             $visibility[] = 'static';
         }
         $rendered .= implode(' ', array_unique($visibility)) . ' function ' . $this->handle . '(';
@@ -146,10 +145,10 @@ class MethodSymbol
         $rendered .= implode(', ', $params) . "){$eol}{{$eol}";
         $class_name = $method->getDeclaringClass()->getName();
         $rendered .= $padding . 'return ';
-        if ($this->classSymbol->isFacade()) {
-            $rendered .= 'static::$instance->' . $method->getName();
-        } elseif ($isStatic) {
+        if ($isStatic) {
             $rendered .= $class_name . '::' . $method->getName();
+        } elseif ($this->classSymbol->isFacade()) {
+            $rendered .= 'static::$instance->' . $method->getName();
         } else {
             $rendered .= 'parent::' . $method->getName();
         }

--- a/web/concrete/src/Support/Symbol/SymbolGenerator.php
+++ b/web/concrete/src/Support/Symbol/SymbolGenerator.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Concrete5 symbol file generator.
- * Inspired by Laravel IDE Helper Generator by Barry vd. Heuvel <barryvdh@gmail.com>
+ * Inspired by Laravel IDE Helper Generator by Barry vd. Heuvel <barryvdh@gmail.com>.
  */
+
 namespace Concrete\Core\Support\Symbol;
 
 use Concrete\Core\Foundation\ClassAliasList;
@@ -10,9 +12,8 @@ use Concrete\Core\Support\Symbol\ClassSymbol\ClassSymbol;
 
 class SymbolGenerator
 {
-
     /**
-     * The ClassSymbol objects
+     * The ClassSymbol objects.
      *
      * @var ClassSymbol[]
      */
@@ -47,6 +48,7 @@ class SymbolGenerator
      * @param string $eol
      * @param string $padding
      * @param callable|null $methodFilter
+     *
      * @return mixed|string
      */
     public function render($eol = "\n", $padding = '    ', $methodFilter = null)
@@ -60,6 +62,7 @@ class SymbolGenerator
             }
         }
         $rendered .= '}'.$eol;
+
         return $rendered;
     }
 }

--- a/web/concrete/src/Support/Symbol/SymbolGenerator.php
+++ b/web/concrete/src/Support/Symbol/SymbolGenerator.php
@@ -46,29 +46,20 @@ class SymbolGenerator
      *
      * @param string $eol
      * @param string $padding
+     * @param callable|null $methodFilter
      * @return mixed|string
      */
-    public function render($eol = PHP_EOL, $padding = '    ')
+    public function render($eol = "\n", $padding = '    ', $methodFilter = null)
     {
         $rendered = "<?php{$eol}namespace {{$eol}{$padding}die('Intended for use with IDE symbol matching only.');{$eol}";
-        $rendered .= "//Generated on " . date('F d, Y \a\t h:i:s a') . $eol;
+        $rendered .= $padding . "//Generated on " . date('r') . $eol;
         foreach ($this->classes as $class) {
-            $rendered_class = explode($eol, $class->render($eol, $padding));
-            $rendered .= $eol . implode(
-                    $eol,
-                    array_map(
-                        function ($val) use ($padding) {
-                            if (substr($val, 0, 1) === '*') {
-                                return $padding . $val;
-                            }
-                            return $padding . $val;
-                        },
-                        $rendered_class));
+            $rendered_class = $class->render($eol, $padding, $methodFilter);
+            if ($rendered_class !== '') {
+                $rendered .= $eol . $padding . str_replace($eol, $eol.$padding, rtrim($rendered_class)) . $eol;
+            }
         }
-        $rendered .= "{$eol}}{$eol}";
-        $rendered = implode($eol, array_map("rtrim", explode($eol, $rendered)));
-        $rendered = preg_replace("~{$eol}{2,}~", "{$eol}{$eol}", $rendered);
+        $rendered .= '}'.$eol;
         return $rendered;
     }
-
 }

--- a/web/concrete/src/Support/Symbol/SymbolGenerator.php
+++ b/web/concrete/src/Support/Symbol/SymbolGenerator.php
@@ -58,10 +58,10 @@ class SymbolGenerator
         foreach ($this->classes as $class) {
             $rendered_class = $class->render($eol, $padding, $methodFilter);
             if ($rendered_class !== '') {
-                $rendered .= $eol . $padding . str_replace($eol, $eol.$padding, rtrim($rendered_class)) . $eol;
+                $rendered .= $eol . $padding . str_replace($eol, $eol . $padding, rtrim($rendered_class)) . $eol;
             }
         }
-        $rendered .= '}'.$eol;
+        $rendered .= '}' . $eol;
 
         return $rendered;
     }


### PR DESCRIPTION
After some discussion in #114, here's a new pull request that simplifies and improves `__IDE_SYMBOLS__.php`:
-  Exclude unnecessary methods
- Fix definition of facade methods
- Simplify indentation
