### PR TITLE
Implements 2283

### DIFF
--- a/web/concrete/blocks/form/auto.js
+++ b/web/concrete/blocks/form/auto.js
@@ -84,6 +84,13 @@ var miniSurvey = {
         } else {
             $('#emailSettings' + mode).hide();
         }
+
+
+        if (radioButton.value == 'date' || radioButton.value == 'datetime') {
+            $('#answerDateDefault' + mode).show();
+        } else {
+            $('#answerDateDefault' + mode).hide();
+        }
     },
     settingsCheck: function (radioButton, mode) {
         if (mode != 'Edit') mode = '';
@@ -104,6 +111,7 @@ var miniSurvey = {
         answerType = $(formID).val();
         var options = encodeURIComponent($('#answerOptions' + mode).val());
         var postStr = 'question=' + encodeURIComponent($('#question' + mode).val()) + '&options=' + options;
+        postStr += '&defaultDate=' + encodeURIComponent($('#defaultDate' + mode).val());
         postStr += '&width=' + escape($('#width' + mode).val());
         postStr += '&height=' + escape($('#height' + mode).val());
         var req = $('input[type="radio"][name="required' + mode + '"]:checked').val();
@@ -183,12 +191,13 @@ var miniSurvey = {
                 $('#widthEdit').val(jsonObj.width);
                 $('#heightEdit').val(jsonObj.height);
                 $('#positionEdit').val(jsonObj.position);
+                $('#defaultDateEdit').val(jsonObj.defaultDate);
                 if (parseInt(jsonObj.required, 10) == 1) {
-                    $('input[name="requiredEdit"][value=1]').prop('checked', true);
-                    $('input[name="requiredEdit"][value=0]').prop('checked', false);
+                    $('input[name="requiredEdit"][value="1"]').prop('checked', true);
+                    $('input[name="requiredEdit"][value="0"]').prop('checked', false);
                 } else {
-                    $('input[name="requiredEdit"][value=1]').prop('checked', false);
-                    $('input[name="requiredEdit"][value=0]').prop('checked', true);
+                    $('input[name="requiredEdit"][value="1"]').prop('checked', false);
+                    $('input[name="requiredEdit"][value="0"]').prop('checked', true);
                 }
 
                 if (jsonObj.inputType == 'email') {
@@ -252,6 +261,7 @@ var miniSurvey = {
         $('#answerType').val('field').change();
         $('#answerOptionsArea').hide();
         $('#answerSettings').hide();
+        $('#answerDateDefault').hide();
         $('#required input').prop('checked', false);
     },
 

--- a/web/concrete/blocks/form/controller.php
+++ b/web/concrete/blocks/form/controller.php
@@ -1,5 +1,6 @@
 <?php 
 namespace Concrete\Block\Form;
+use Concrete\Core\Block\BlockType\BlockType;
 use Loader;
 use \Concrete\Core\Block\BlockController;
 use User;
@@ -243,8 +244,8 @@ class Controller extends BlockController {
 			
 			$rs=$db->query("SELECT * FROM {$this->btQuestionsTablename} WHERE questionSetId=$oldQuestionSetId AND bID=".intval($this->bID) );
 			while( $row=$rs->fetchRow() ){
-				$v=array($newQuestionSetId,intval($row['msqID']), intval($newBID), $row['question'],$row['inputType'],$row['options'],$row['position'],$row['width'],$row['height'],$row['required']);
-				$sql= "INSERT INTO {$this->btQuestionsTablename} (questionSetId,msqID,bID,question,inputType,options,position,width,height,required) VALUES (?,?,?,?,?,?,?,?,?,?)";
+				$v=array($newQuestionSetId,intval($row['msqID']), intval($newBID), $row['question'],$row['inputType'],$row['options'],$row['position'],$row['width'],$row['height'],$row['required'],$row['defaultDate']);
+				$sql= "INSERT INTO {$this->btQuestionsTablename} (questionSetId,msqID,bID,question,inputType,options,position,width,height,required,defaultDate) VALUES (?,?,?,?,?,?,?,?,?,?,?)";
 				$db->Execute($sql, $v);
 			}
 			

--- a/web/concrete/blocks/form/db.xml
+++ b/web/concrete/blocks/form/db.xml
@@ -73,8 +73,11 @@
 		<field name="height" type="I">
 			<unsigned />
 			<default value="3" />
-		</field> 
-		<field name="required" type="I">
+		</field>
+        <field name="defaultDate" type="C" size="255">
+            <default value="" />
+        </field>
+        <field name="required" type="I">
 			<default value="0"/>
 		</field>  
 		<index name="questionSetId">

--- a/web/concrete/blocks/form/form_setup_html.php
+++ b/web/concrete/blocks/form/form_setup_html.php
@@ -1,10 +1,8 @@
 <?php 
 defined('C5_EXECUTE') or die("Access Denied.");
-/* @var $uh ConcreteUrlsHelper */ 
 $uh = Loader::helper('concrete/urls');
-/* @var $form FormHelper */
 $form = Loader::helper('form');
-/* @var $ih ConcreteInterfaceHelper */
+$datetime = loader::helper('form/date_time');
 $ih = Loader::helper('concrete/ui');
 $a = $view->getAreaObject();
 $bt = BlockType::getByHandle('form');
@@ -154,7 +152,21 @@ $addSelected = true;
 			</div>
 		</div>
 
-		<div class="form-group">
+        <div id="answerDateDefault">
+            <div class="form-group">
+                <?=$form->label('defaultDate', t('Default Value'))?>
+                <?=$form->select(
+                    'defaultDate',
+                    array(
+                        '' => t('Blank'),
+                        'now' => t('Current Date/Time'),
+                    ),
+                    'blank'
+                )?>
+            </div>
+        </div>
+
+        <div class="form-group">
 			<label class="control-label"><?=t('Required')?></label>
 			<div class="radio"><label><?=$form->radio('required', 1)?> <?=t('Yes')?></label></div>
 			<div class="radio"><label><?=$form->radio('required', 0)?> <?=t('No')?></label></div>
@@ -225,6 +237,20 @@ $addSelected = true;
 				</div>
 			</div>
 
+            <div id="answerDateDefaultEdit">
+                <div class="form-group">
+                    <?=$form->label('defaultDateEdit', t('Default Value'))?>
+                    <?=$form->select(
+                        'defaultDateEdit',
+                        array(
+                            '' => t('Blank'),
+                            'now' => t('Current Date/Time'),
+                        ),
+                        'blank'
+                    )?>
+                </div>
+            </div>
+
 			<div class="form-group">
 				<label class="control-label"><?=t('Required')?></label>
 				<div class="radio"><label><?=$form->radio('requiredEdit', 1)?> <?=t('Yes')?></label></div>
@@ -239,7 +265,7 @@ $addSelected = true;
 			</div>
 		</fieldset>
 		
-		<input type="hidden" id="positionEdit" name="position" type="text" value="1000" />
+		<input type="hidden" id="positionEdit" name="position" value="1000" />
 		
 		<div>
 			<?=$ih->button(t('Cancel'), 'javascript:void(0)', 'left', '', array('id' => 'cancelEditQuestion'))?>
@@ -264,7 +290,7 @@ $addSelected = true;
 
 <style type="text/css">
 	div.miniSurveyQuestion {
-		float: left; 
+		float: left;
 		width: 80%;
 	}
 	div.miniSurveyOptions {


### PR DESCRIPTION
Implements #2283

This implements setting a default date to blank or current date/time. It also fixes a bug in the datetime type where when you submit it, if validation fails, it reverts to the submitted value instead of the default value.

It looked like the form block was already being refreshed so I think we should be good to go for upgrade on the database side of things