### PR TITLE
Avoid fatal error on PageType in limited situations

### DIFF
--- a/web/concrete/controllers/panel/detail/page/composer.php
+++ b/web/concrete/controllers/panel/detail/page/composer.php
@@ -8,6 +8,7 @@ use Loader;
 use PageTemplate;
 use User;
 use Core;
+use \Concrete\Core\Page\Type\PublishTarget\Configuration\Configuration as PageTypePublishTargetConfiguration;
 
 class Composer extends BackendInterfacePageController {
 
@@ -128,7 +129,9 @@ class Composer extends BackendInterfacePageController {
 
 			/// set the target
 			$configuredTarget = $pagetype->getPageTypePublishTargetObject();
-			$targetPageID = $configuredTarget->getPageTypePublishTargetConfiguredTargetParentPageID();
+			if ($configuredTarget instanceof PageTypePublishTargetConfiguration) {
+				$targetPageID = $configuredTarget->getPageTypePublishTargetConfiguredTargetParentPageID();
+			}
 			if (!$targetPageID) {
 				$targetPageID = $_POST['cParentID'];
 			}

--- a/web/concrete/controllers/panel/detail/page/composer.php
+++ b/web/concrete/controllers/panel/detail/page/composer.php
@@ -129,6 +129,7 @@ class Composer extends BackendInterfacePageController {
 
 			/// set the target
 			$configuredTarget = $pagetype->getPageTypePublishTargetObject();
+			$targetPageID = 0;
 			if ($configuredTarget instanceof PageTypePublishTargetConfiguration) {
 				$targetPageID = $configuredTarget->getPageTypePublishTargetConfiguredTargetParentPageID();
 			}

--- a/web/concrete/src/Page/Type/Type.php
+++ b/web/concrete/src/Page/Type/Type.php
@@ -1047,9 +1047,11 @@ class Type extends Object implements \Concrete\Core\Permission\ObjectInterface
 
         // now we setup in the initial configurated page target
         $target = $this->getPageTypePublishTargetObject();
-        $cParentID = $target->getDefaultParentPageID();
-        if ($cParentID > 0) {
-            $p->setPageDraftTargetParentPageID($cParentID);
+        if ($target instanceof PageTypePublishTargetConfiguration) {
+            $cParentID = $target->getDefaultParentPageID();
+            if ($cParentID > 0) {
+                $p->setPageDraftTargetParentPageID($cParentID);
+            }
         }
 
         // we have to publish the controls to the page. i'm not sure why

--- a/web/concrete/src/Page/Type/Type.php
+++ b/web/concrete/src/Page/Type/Type.php
@@ -1014,7 +1014,10 @@ class Type extends Object implements \Concrete\Core\Permission\ObjectInterface
     public function canPublishPageTypeBeneathPage(\Concrete\Core\Page\Page $page)
     {
         $target = $this->getPageTypePublishTargetObject();
-        return $target->canPublishPageTypeBeneathTarget($this, $page);
+        if ($target instanceof PageTypePublishTargetConfiguration) {
+            return $target->canPublishPageTypeBeneathTarget($this, $page);
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
I'm testing some packages now...an e-commerse package adds a page type manually, but does not set a publish target object to the new page type. Because of this, I've got fatal errors on adding new page. I think developers should set a publish target object to a page type object, but this change will help beginners.