### PR TITLE
Better view of concrete5 configuration on error

### DIFF
--- a/web/concrete/src/Error/Handler/ErrorHandler.php
+++ b/web/concrete/src/Error/Handler/ErrorHandler.php
@@ -97,8 +97,10 @@ class ErrorHandler extends PrettyPageHandler
         foreach ($config as $key => $value) {
             if (is_array($value)) {
                 $flat = array_merge($flat, $this->flatConfig($value, "{$group}.{$key}"));
-            } else {
+            } elseif (is_string($value)) {
                 $flat["{$group}.{$key}"] = $value;
+            } else {
+                $flat["{$group}.{$key}"] = json_encode($value);
             }
         }
 


### PR DESCRIPTION
Before:
![pre](https://cloud.githubusercontent.com/assets/928116/7364432/a5a06612-ed86-11e4-9c70-78a6e0d85a21.png)

After:
![post](https://cloud.githubusercontent.com/assets/928116/7364434/aa922cfa-ed86-11e4-8bce-3f2a73738039.png)
