### PR TITLE
Fixed non-PNG decoding in thumbnail save (Fixes #2341)

### DIFF
--- a/web/concrete/tools/files/importers/thumbnail.php
+++ b/web/concrete/tools/files/importers/thumbnail.php
@@ -44,7 +44,7 @@ if ($thumbnail) {
      * be revised.
      */
     $filesystem = $fsl->getFileSystemObject();
-    $filesystem->update($type_version->getFilePath($file_version), base64_decode(preg_replace('/data:image\/(png|jpeg);base64,/', '', $imgData)));
+    $filesystem->update($type_version->getFilePath($file_version), base64_decode(preg_replace('/data:image\/(png|jpeg);base64,/', '', $imgData, 1)));
 
     die('{"error":0}');
 }

--- a/web/concrete/tools/files/importers/thumbnail.php
+++ b/web/concrete/tools/files/importers/thumbnail.php
@@ -37,7 +37,6 @@ foreach ($thumbnails as $thumb) {
 }
 
 if ($thumbnail) {
-    /** @var StorageLocation $fsl */
     $fsl = $f->getFileStorageLocationObject();
 
     /**
@@ -45,7 +44,7 @@ if ($thumbnail) {
      * be revised.
      */
     $filesystem = $fsl->getFileSystemObject();
-    $filesystem->update($type_version->getFilePath($file_version), base64_decode(str_replace('data:image/png;base64,', '', $imgData)));
+    $filesystem->update($type_version->getFilePath($file_version), base64_decode(preg_replace('/data:image\/(png|jpeg);base64,/', '', $imgData)));
 
     die('{"error":0}');
 }


### PR DESCRIPTION
Fixes #2341.

Borrowed the same fix from #2142:

`str_replace('data:image/png;base64,', '', $imgData)`
became
`preg_replace('/data:image\/(png|jpeg);base64,/', '', $imgData, 1)`