### PR TITLE
Fix plural rule issue with site interface translation

### DIFF
--- a/web/concrete/src/Multilingual/Service/Extractor.php
+++ b/web/concrete/src/Multilingual/Service/Extractor.php
@@ -154,6 +154,7 @@ class Extractor
         $mo = DIR_LANGUAGES_SITE_INTERFACE . '/' . $section->getLocale() . '.mo';
 
         PoGenerator::toFile($translations, $po);
+        $translations = PoExtractor::fromFile($po);
 
         /* Do not generate mo for empty catalog, it crashes Zend\I18n gettext loader */
         $empty = true;


### PR DESCRIPTION
When I saved site translations to file, I got a Exception. The message is "Plural rule of merging text domain is not compatible with the current one". I can reproduce this issue when I have a Japanese section in my sitemap. I have also tested with two languages, English and Italian, but there is no problem. 

Finally, I found this addition magically solves the issue, but I can't understand why.