### PR TITLE
(Re)Create test database in bootstrap.php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
 
 before_script:
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "short_open_tag = On" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
-  - mysql -e 'CREATE DATABASE concrete5_tests;'
   - cd web/concrete
   - composer install
   - cd ../../tests

--- a/tests/tests/bootstrap.php
+++ b/tests/tests/bootstrap.php
@@ -78,12 +78,28 @@ $config->set(
         'username' => 'travis',
         'password' => '',
         'charset' => 'utf8'
-    ));
+    )
+);
+$config->set(
+    'database.connections.travisWithoutDB',
+    array(
+        'driver' => 'c5_pdo_mysql',
+        'server' => 'localhost',
+        'username' => 'travis',
+        'password' => '',
+        'charset' => 'utf8'
+    )
+);
 
 $config->get('concrete');
 $config->set('concrete.cache.blocks', false);
 $config->set('concrete.cache.pages', false);
 $config->set('concrete.cache.enabled', false);
+
+$cn = $cms->make('database')->connection('travisWithoutDB');
+$cn->query('DROP DATABASE IF EXISTS concrete5_tests');
+$cn->query('CREATE DATABASE concrete5_tests');
+$cn->close();
 
 /**
  * Kill this because it plays hell with phpunit.


### PR DESCRIPTION
For local tests, it's handy to (re)create the test DB in the bootstrap.php