### PR TITLE
Add fsDisplayOrder sort to getFileSetFiles

### DIFF
--- a/web/concrete/src/File/Set/File.php
+++ b/web/concrete/src/File/Set/File.php
@@ -11,7 +11,7 @@ class File
     public static function getFileSetFiles(Set $fs)
     {
         $db = Loader::db();
-        $r = $db->query('SELECT fsfID FROM FileSetFiles WHERE fsID = ?', array($fs->getFileSetID()));
+        $r = $db->query('SELECT fsfID FROM FileSetFiles WHERE fsID = ? ORDER BY fsDisplayOrder ASC', array($fs->getFileSetID()));
         $files = array();
         while ($row = $r->FetchRow()) {
             $fsf = static::getByID($row['fsfID']);


### PR DESCRIPTION
I have a Press Photo block that pulls a specific File Set. I made a change to the sort order of the files within the File Set using the File Manager > File Sets > Files in Set dashboard. However, my block wasn't reflecting the update to the sort order.

I added the ORDER BY clause to the query so that the result set would honor the fsDisplayOrder values.