### PR TITLE
Beautify form helper

### DIFF
--- a/tests/tests/Core/Form/Service/FormTest.php
+++ b/tests/tests/Core/Form/Service/FormTest.php
@@ -1,0 +1,819 @@
+<?php
+
+namespace Concrete\Tests\Core\Form\Service;
+
+use Core;
+
+class FormTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Concrete\Core\Form\Service\Form
+     */
+    protected static $formHelper;
+
+    /**
+     * @var array
+     */
+    protected $initialState;
+
+    public static function setUpBeforeClass()
+    {
+        self::$formHelper = Core::make('helper/form');
+    }
+    protected function setUp()
+    {
+        $this->initialState = array(
+            'get' => $_GET,
+            'post' => $_POST,
+            'request' => $_REQUEST,
+            'requestMethod' => isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : null,
+        );
+        $_GET = array();
+        $_POST = array();
+        $_REQUEST = array();
+        unset($_SERVER['REQUEST_METHOD']);
+    }
+    protected function tearDown()
+    {
+        $_GET = $this->initialState['get'];
+        $_POST = $this->initialState['post'];
+        $_REQUEST = $this->initialState['request'];
+        unset($_SERVER['REQUEST_METHOD']);
+        if (isset($this->initialState['REQUEST_METHOD'])) {
+            $_SERVER['REQUEST_METHOD'] = $this->initialState['REQUEST_METHOD'];
+        }
+    }
+
+    public function providerTestCreateElements()
+    {
+        return array(
+            // submit
+            array(
+                'submit',
+                array('Key', 'Value'),
+                '<input type="submit" class="btn ccm-input-submit" id="Key" name="Key" value="Value" />',
+            ),
+            array(
+                'submit',
+                array('Key[]', 'Value'),
+                '<input type="submit" class="btn ccm-input-submit" id="Key[]" name="Key[]" value="Value" />',
+
+            ),
+            array(
+                'submit',
+                array('Key', 'Value', array('class' => 'MY-CLASS')),
+                '<input type="submit" class="MY-CLASS btn ccm-input-submit" id="Key" name="Key" value="Value" />',
+            ),
+            array(
+                'submit',
+                array('Key', 'Value', array(), 'MY-CLASS'),
+                '<input type="submit" class="btn ccm-input-submit MY-CLASS" id="Key" name="Key" value="Value" />',
+            ),
+            // button
+            array(
+                'button',
+                array('Key', 'Value'),
+                '<input type="button" class="btn ccm-input-button" id="Key" name="Key" value="Value" />',
+            ),
+            array(
+                'button',
+                array('Key[]', 'Value'),
+                '<input type="button" class="btn ccm-input-button" id="Key[]" name="Key[]" value="Value" />',
+            ),
+            array(
+                'button',
+                array('Key', 'Value', array('class' => 'MY-CLASS')),
+                '<input type="button" class="MY-CLASS btn ccm-input-button" id="Key" name="Key" value="Value" />',
+            ),
+            array(
+                'button',
+                array('Key', 'Value', array(), 'MY-CLASS'),
+                '<input type="button" class="btn ccm-input-button MY-CLASS" id="Key" name="Key" value="Value" />',
+            ),
+            // label
+            array(
+                'label',
+                array('ForKey', '<b>label</b>'),
+                '<label for="ForKey" class="control-label"><b>label</b></label>',
+            ),
+            array(
+                'label',
+                array('ForKey[]', 'text'),
+                '<label for="ForKey[]" class="control-label">text</label>',
+            ),
+            array(
+                'label',
+                array('ForKey', 'text', array()),
+                '<label for="ForKey" class="control-label">text</label>',
+            ),
+            array(
+                'label',
+                array('ForKey', 'text', array('class' => 'MY-CLASS')),
+                '<label for="ForKey" class="MY-CLASS control-label">text</label>',
+            ),
+            // file
+            array(
+                'file',
+                array('Key'),
+                '<input type="file" id="Key" name="Key" value="" class="form-control" />',
+            ),
+            array(
+                'file',
+                array('Key[]'),
+                '<input type="file" id="Key[]" name="Key[]" value="" class="form-control" />',
+            ),
+            array(
+                'file',
+                array('Key', array()),
+                '<input type="file" id="Key" name="Key" value="" class="form-control" />',
+            ),
+            array(
+                'file',
+                array('Key', array('class' => 'MY-CLASS')),
+                '<input type="file" id="Key" name="Key" value="" class="MY-CLASS form-control" />',
+            ),
+            // hidden
+            array(
+                'hidden',
+                array('Key'),
+                '<input type="hidden" id="Key" name="Key" value="" />',
+            ),
+            array(
+                'hidden',
+                array('Key', null),
+                '<input type="hidden" id="Key" name="Key" value="" />',
+            ),
+            array(
+                'hidden',
+                array('Key', null, array('class' => 'MY-CLASS')),
+                '<input type="hidden" id="Key" name="Key" class="MY-CLASS" value="" />',
+            ),
+            array(
+                'hidden',
+                array('Key', ''),
+                '<input type="hidden" id="Key" name="Key" value="" />',
+            ),
+            array(
+                'hidden',
+                array('Key', '', array('class' => 'MY-CLASS')),
+                '<input type="hidden" id="Key" name="Key" class="MY-CLASS" value="" />',
+            ),
+            array(
+                'hidden',
+                array('Key', 'Field value'),
+                '<input type="hidden" id="Key" name="Key" value="Field value" />',
+            ),
+            array(
+                'hidden',
+                array('Key', 'Field value', array('class' => 'MY-CLASS', 'data-my-data' => 'My value')),
+                '<input type="hidden" id="Key" name="Key" class="MY-CLASS" data-my-data="My value" value="Field value" />',
+            ),
+            array(
+                'hidden',
+                array('Key', false),
+                '<input type="hidden" id="Key" name="Key" value="" />',
+            ),
+            array(
+                'hidden',
+                array('Key', 1),
+                '<input type="hidden" id="Key" name="Key" value="1" />',
+            ),
+            array(
+                'hidden',
+                array('Key', 'Original value'),
+                '<input type="hidden" id="Key" name="Key" value="Original value" />',
+            ),
+            array(
+                'hidden',
+                array('Key', 'Original value'),
+                '<input type="hidden" id="Key" name="Key" value="" />',
+                array('Key' => ''),
+            ),
+            array(
+                'hidden',
+                array('Key[]'),
+                '<input type="hidden" id="Key[]" name="Key[]" value="" />',
+            ),
+            array(
+                'hidden',
+                array('Key', 'Original value'),
+                '<input type="hidden" id="Key" name="Key" value="Received value" />',
+                array('Key' => 'Received value'),
+            ),
+            array(
+                'hidden',
+                array('Key[subkey1][subkey2]', 'Original value'),
+                '<input type="hidden" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" value="Original value" />',
+                array('Key' => 'Received value'),
+            ),
+            array(
+                'hidden',
+                array('Key[subkey1][subkey2]', 'Original value'),
+                '<input type="hidden" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" value="Original value" />',
+                array('Key' => array('subkey1' => 'Received value')),
+            ),
+            array(
+                'hidden',
+                array('Key[subkey1][subkey2]', 'Original value'),
+                '<input type="hidden" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" value="Received value" />',
+                array('Key' => array('subkey1' => array('subkey2' => 'Received value'))),
+            ),
+            array(
+                'hidden',
+                array('Key[subkey1][subkey2]', 'Original value'),
+                '<input type="hidden" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" value="Original value" />',
+                array('Key' => array('subkey1' => array('subkey2' => array('subkey3' => 'Received value')))),
+            ),
+            // checkbox
+            array(
+                'checkbox',
+                array('Key', 'Value'),
+                '<input type="checkbox" id="Key" name="Key" class="ccm-input-checkbox" value="Value" />',
+            ),
+            array(
+                'checkbox',
+                array('Key', 'Value', false),
+                '<input type="checkbox" id="Key" name="Key" class="ccm-input-checkbox" value="Value" />',
+            ),
+            array(
+                'checkbox',
+                array('Key', 'Value', null),
+                '<input type="checkbox" id="Key" name="Key" class="ccm-input-checkbox" value="Value" />',
+            ),
+            array(
+                'checkbox',
+                array('Key', 'Value', 0),
+                '<input type="checkbox" id="Key" name="Key" class="ccm-input-checkbox" value="Value" />',
+            ),
+            array(
+                'checkbox',
+                array('Key', 'Value', '0'),
+                '<input type="checkbox" id="Key" name="Key" class="ccm-input-checkbox" value="Value" />',
+            ),
+            array(
+                'checkbox',
+                array('Key', 'Value', true),
+                '<input type="checkbox" id="Key" name="Key" class="ccm-input-checkbox" value="Value" checked="checked" />',
+            ),
+            array(
+                'checkbox',
+                array('Key', 'Value', '1'),
+                '<input type="checkbox" id="Key" name="Key" class="ccm-input-checkbox" value="Value" checked="checked" />',
+            ),
+            array(
+                'checkbox',
+                array('Key', 'Value', true),
+                '<input type="checkbox" id="Key" name="Key" class="ccm-input-checkbox" value="Value" />',
+                array('OtherField' => 'Other value'),
+            ),
+            array(
+                'checkbox',
+                array('Key', 'Value', false),
+                '<input type="checkbox" id="Key" name="Key" class="ccm-input-checkbox" value="Value" checked="checked" />',
+                array('Key' => 'Value'),
+            ),
+            array(
+                'checkbox',
+                array('Key', 'Value', false),
+                '<input type="checkbox" id="Key" name="Key" class="ccm-input-checkbox" value="Value" />',
+                array('Key' => ''),
+            ),
+            array(
+                'checkbox',
+                array('Key', 'Value', false),
+                '<input type="checkbox" id="Key" name="Key" class="ccm-input-checkbox" value="Value" />',
+                array('Key' => 'Wrong value'),
+            ),
+            array(
+                'checkbox',
+                array('Key[]', 'Value'),
+                '<input type="checkbox" id="Key_Value" name="Key[]" class="ccm-input-checkbox" value="Value" />',
+            ),
+            array(
+                'checkbox',
+                array('Key[]', 'Value', true),
+                '<input type="checkbox" id="Key_Value" name="Key[]" class="ccm-input-checkbox" value="Value" checked="checked" />',
+            ),
+            array(
+                'checkbox',
+                array('Key[]', 'Value', true),
+                '<input type="checkbox" id="Key_Value" name="Key[]" class="ccm-input-checkbox" value="Value" />',
+                array('OtherField' => 'Other value'),
+            ),
+            array(
+                'checkbox',
+                array('Key[]', 'Value', false),
+                '<input type="checkbox" id="Key_Value" name="Key[]" class="ccm-input-checkbox" value="Value" checked="checked" />',
+                array('Key' => 'Value'),
+            ),
+            array(
+                'checkbox',
+                array('Key[]', 'Value', false),
+                '<input type="checkbox" id="Key_Value" name="Key[]" class="ccm-input-checkbox" value="Value" />',
+                array('Key' => 'Other value'),
+            ),
+            array(
+                'checkbox',
+                array('Key[]', 'Value', false),
+                '<input type="checkbox" id="Key_Value" name="Key[]" class="ccm-input-checkbox" value="Value" checked="checked" />',
+                array('Key' => array('Look', 'for', 'Value', 'in', 'this', 'array')),
+            ),
+            array(
+                'checkbox',
+                array('Key[subkey1][subkey2]', 'Value', false),
+                '<input type="checkbox" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" class="ccm-input-checkbox" value="Value" />',
+                array('Key' => 'Value'),
+            ),
+            array(
+                'checkbox',
+                array('Key[subkey1][subkey2]', 'Value', false),
+                '<input type="checkbox" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" class="ccm-input-checkbox" value="Value" />',
+                array('Key' => array('subkey1' => 'Value')),
+            ),
+            array(
+                'checkbox',
+                array('Key[subkey1][subkey2]', 'Value', false),
+                '<input type="checkbox" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" class="ccm-input-checkbox" value="Value" checked="checked" />',
+                array('Key' => array('subkey1' => array('subkey2' => 'Value'))),
+            ),
+            array(
+                'checkbox',
+                array('Key[subkey1][subkey2]', 'Value', false),
+                '<input type="checkbox" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" class="ccm-input-checkbox" value="Value" checked="checked" />',
+                array('Key' => array('subkey1' => array('subkey2' => array('subkey3' => 'Value')))),
+            ),
+            array(
+                'checkbox',
+                array('Key[subkey1][subkey2]', 'Value', false),
+                '<input type="checkbox" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" class="ccm-input-checkbox" value="Value" />',
+                array('Key' => array('subkey1' => array('subkey2' => array('subkey3' => 'Other value')))),
+            ),
+            // textarea
+            array(
+                'textarea',
+                array('Key'),
+                '<textarea id="Key" name="Key" class="form-control"></textarea>',
+            ),
+            array(
+                'textarea',
+                array('Key', 'Value'),
+                '<textarea id="Key" name="Key" class="form-control">Value</textarea>',
+            ),
+            array(
+                'textarea',
+                array('Key', array('class' => 'MY-CLASS')),
+                '<textarea id="Key" name="Key" class="MY-CLASS form-control"></textarea>',
+            ),
+            array(
+                'textarea',
+                array('Key', '', array('class' => 'MY-CLASS')),
+                '<textarea id="Key" name="Key" class="MY-CLASS form-control"></textarea>',
+            ),
+            array(
+                'textarea',
+                array('Key', 'Value', array('class' => 'MY-CLASS')),
+                '<textarea id="Key" name="Key" class="MY-CLASS form-control">Value</textarea>',
+            ),
+            array(
+                'textarea',
+                array('Key', 'Original value'),
+                '<textarea id="Key" name="Key" class="form-control"></textarea>',
+                array('Key' => ''),
+            ),
+            array(
+                'textarea',
+                array('Key', 'Original value'),
+                '<textarea id="Key" name="Key" class="form-control">Received value</textarea>',
+                array('Key' => 'Received value'),
+            ),
+            array(
+                'textarea',
+                array('Key[subkey1][subkey2]', 'Original value'),
+                '<textarea id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" class="form-control">Original value</textarea>',
+                array('Key' => 'Received value'),
+            ),
+            array(
+                'textarea',
+                array('Key[subkey1][subkey2]', 'Original value'),
+                '<textarea id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" class="form-control">Original value</textarea>',
+                array('Key' => array('subkey1' => 'Received value')),
+            ),
+            array(
+                'textarea',
+                array('Key[subkey1][subkey2]', 'Original value'),
+                '<textarea id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" class="form-control">Received value</textarea>',
+                array('Key' => array('subkey1' => array('subkey2' => 'Received value'))),
+            ),
+            array(
+                'textarea',
+                array('Key[subkey1][subkey2]', 'Original value'),
+                '<textarea id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" class="form-control">Original value</textarea>',
+                array('Key' => array('subkey1' => array('subkey2' => array('subkey3' => 'Received value')))),
+            ),
+            // radio
+            array(
+                'radio',
+                array('Key', 'Value'),
+                '<input type="radio" id="Key**UNIQUENUMBER**" name="Key" value="Value" class="ccm-input-radio" />',
+            ),
+            array(
+                'radio',
+                array('Key', 'Value', 'Incorrect value'),
+                '<input type="radio" id="Key**UNIQUENUMBER**" name="Key" value="Value" class="ccm-input-radio" />',
+            ),
+            array(
+                'radio',
+                array('Key', 'Value', 'Value'),
+                '<input type="radio" id="Key**UNIQUENUMBER**" name="Key" value="Value" class="ccm-input-radio" checked="checked" />',
+            ),
+            array(
+                'radio',
+                array('Key', 'Value', array('class' => 'MY-CLASS', 'data-custom' => 'My custom data')),
+                '<input type="radio" id="Key**UNIQUENUMBER**" name="Key" value="Value" class="MY-CLASS ccm-input-radio" data-custom="My custom data" />',
+            ),
+            array(
+                'radio',
+                array('Key', 'Value', 'Value', array('class' => 'MY-CLASS')),
+                '<input type="radio" id="Key**UNIQUENUMBER**" name="Key" value="Value" class="MY-CLASS ccm-input-radio" checked="checked" />',
+            ),
+            array(
+                'radio',
+                array('Key', 'Value'),
+                '<input type="radio" id="Key**UNIQUENUMBER**" name="Key" value="Value" class="ccm-input-radio" />',
+                array('Key' => ''),
+            ),
+            array(
+                'radio',
+                array('Key', 'Value'),
+                '<input type="radio" id="Key**UNIQUENUMBER**" name="Key" value="Value" class="ccm-input-radio" />',
+                array('Key' => 'Invalid value'),
+            ),
+            array(
+                'radio',
+                array('Key', 'Value'),
+                '<input type="radio" id="Key**UNIQUENUMBER**" name="Key" value="Value" class="ccm-input-radio" checked="checked" />',
+                array('Key' => 'Value'),
+            ),
+            array(
+                'radio',
+                array('Key', 'Value'),
+                '<input type="radio" id="Key**UNIQUENUMBER**" name="Key" value="Value" class="ccm-input-radio" />',
+                array('OtherKey' => 'OtherValue'),
+            ),
+            array(
+                'radio',
+                array('Key[subkey1][subkey2]', 'Value'),
+                '<input type="radio" id="Key[subkey1][subkey2]**UNIQUENUMBER**" name="Key[subkey1][subkey2]" value="Value" class="ccm-input-radio" />',
+                array('Key' => array('subkey1' => array('subkey2' => 'Value'))),
+            ),
+            // inputType (text, number, email, telephone, url, search, password)
+            array(
+                'text',
+                array('Key'),
+                '<input type="text" id="Key" name="Key" value="" class="form-control ccm-input-text" />',
+            ),
+            array(
+                'number',
+                array('Key'),
+                '<input type="number" id="Key" name="Key" value="" class="form-control ccm-input-number" />',
+            ),
+            array(
+                'email',
+                array('Key'),
+                '<input type="email" id="Key" name="Key" value="" class="form-control ccm-input-email" />',
+            ),
+            array(
+                'telephone',
+                array('Key'),
+                '<input type="tel" id="Key" name="Key" value="" class="form-control ccm-input-tel" />',
+            ),
+            array(
+                'url',
+                array('Key'),
+                '<input type="url" id="Key" name="Key" value="" class="form-control ccm-input-url" />',
+            ),
+            array(
+                'search',
+                array('Key'),
+                '<input type="search" id="Key" name="Key" value="" class="form-control ccm-input-search" />',
+            ),
+            array(
+                'password',
+                array('Key'),
+                '<input type="password" id="Key" name="Key" value="" class="form-control ccm-input-password" />',
+            ),
+            array(
+                'text',
+                array('Key', null),
+                '<input type="text" id="Key" name="Key" value="" class="form-control ccm-input-text" />',
+            ),
+            array(
+                'text',
+                array('Key', false),
+                '<input type="text" id="Key" name="Key" value="" class="form-control ccm-input-text" />',
+            ),
+            array(
+                'text',
+                array('Key', 'Value'),
+                '<input type="text" id="Key" name="Key" value="Value" class="form-control ccm-input-text" />',
+            ),
+            array(
+                'text',
+                array('Key', array('data-mine' => 'MY DATA', 'class' => 'MY-CLASS')),
+                '<input type="text" id="Key" name="Key" value="" data-mine="MY DATA" class="MY-CLASS form-control ccm-input-text" />',
+            ),
+            array(
+                'text',
+                array('Key', 'Value', array('class' => 'MY-CLASS')),
+                '<input type="text" id="Key" name="Key" value="Value" class="MY-CLASS form-control ccm-input-text" />',
+            ),
+            array(
+                'text',
+                array('Key', 'Value'),
+                '<input type="text" id="Key" name="Key" value="Received value" class="form-control ccm-input-text" />',
+                array('Key' => 'Received value'),
+            ),
+            array(
+                'text',
+                array('Key', 'Value'),
+                '<input type="text" id="Key" name="Key" value="Value" class="form-control ccm-input-text" />',
+                array('OtherKey' => 'Other value'),
+            ),
+            array(
+                'text',
+                array('Key[subkey1][subkey2]', 'Original value'),
+                '<input type="text" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" value="Original value" class="form-control ccm-input-text" />',
+            ),
+            array(
+                'text',
+                array('Key[subkey1][subkey2]', 'Original value'),
+                '<input type="text" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" value="Original value" class="form-control ccm-input-text" />',
+                array('OtherKey' => 'Other value'),
+            ),
+            array(
+                'text',
+                array('Key[subkey1][subkey2]', 'Original value'),
+                '<input type="text" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" value="Original value" class="form-control ccm-input-text" />',
+                array('Key' => 'Received value'),
+            ),
+            array(
+                'text',
+                array('Key[subkey1][subkey2]', 'Original value'),
+                '<input type="text" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" value="Original value" class="form-control ccm-input-text" />',
+                array('Key' => array('subkey1' => 'Received value')),
+            ),
+            array(
+                'text',
+                array('Key[subkey1][subkey2]', 'Original value'),
+                '<input type="text" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" value="Received value" class="form-control ccm-input-text" />',
+                array('Key' => array('subkey1' => array('subkey2' => 'Received value'))),
+            ),
+            array(
+                'text',
+                array('Key[subkey1][subkey2]', 'Original value'),
+                '<input type="text" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" value="Original value" class="form-control ccm-input-text" />',
+                array('Key' => array('subkey1' => array('subkey2' => array('subkey3' => 'Received value')))),
+            ),
+            // select
+            array(
+                'select',
+                array('Key', null),
+                '<select id="Key" name="Key" class="form-control"></select>',
+            ),
+            array(
+                'select',
+                array('Key', false),
+                '<select id="Key" name="Key" class="form-control"></select>',
+            ),
+            array(
+                'select',
+                array('Key', ''),
+                '<select id="Key" name="Key" class="form-control"></select>',
+            ),
+            array(
+                'select',
+                array('Key', array()),
+                '<select id="Key" name="Key" class="form-control"></select>',
+            ),
+            array(
+                'select',
+                array('Key', array('One' => 'First', 'Two' => 'Second')),
+                '<select id="Key" name="Key" class="form-control"><option value="One">First</option><option value="Two">Second</option></select>',
+            ),
+            array(
+                'select',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<select id="Key" name="Key" ccm-passed-value="Two" class="form-control"><option value="One">First</option><option value="Two" selected="selected">Second</option></select>',
+            ),
+            array(
+                'select',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), array('class' => 'MY-CLASS', 'data-mine' => "MY DATA")),
+                '<select id="Key" name="Key" class="MY-CLASS form-control" data-mine="MY DATA"><option value="One">First</option><option value="Two">Second</option></select>',
+            ),
+            array(
+                'select',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), 'Two', array('class' => 'MY-CLASS', 'data-mine' => "MY DATA")),
+                '<select id="Key" name="Key" class="MY-CLASS form-control" data-mine="MY DATA" ccm-passed-value="Two"><option value="One">First</option><option value="Two" selected="selected">Second</option></select>',
+            ),
+            array(
+                'select',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), 'Invalid'),
+                '<select id="Key" name="Key" ccm-passed-value="Invalid" class="form-control"><option value="One">First</option><option value="Two">Second</option></select>',
+            ),
+            array(
+                'select',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<select id="Key" name="Key" ccm-passed-value="Two" class="form-control"><option value="One">First</option><option value="Two" selected="selected">Second</option></select>',
+                array('OtherField' => 'OtherValue'),
+            ),
+            array(
+                'select',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<select id="Key" name="Key" ccm-passed-value="Two" class="form-control"><option value="One">First</option><option value="Two">Second</option></select>',
+                array('Key' => ''),
+            ),
+            array(
+                'select',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<select id="Key" name="Key" ccm-passed-value="Two" class="form-control"><option value="One" selected="selected">First</option><option value="Two">Second</option></select>',
+                array('Key' => 'One'),
+            ),
+            array(
+                'select',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<select id="Key" name="Key" ccm-passed-value="Two" class="form-control"><option value="One">First</option><option value="Two">Second</option></select>',
+                array('Key' => 'Invalid'),
+            ),
+            array(
+                'select',
+                array('Key[subkey1][subkey2]', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<select id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" ccm-passed-value="Two" class="form-control"><option value="One">First</option><option value="Two" selected="selected">Second</option></select>',
+                array('Key' => 'One'),
+            ),
+            array(
+                'select',
+                array('Key[subkey1][subkey2]', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<select id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" ccm-passed-value="Two" class="form-control"><option value="One">First</option><option value="Two" selected="selected">Second</option></select>',
+                array('Key' => array('subkey1' => 'One')),
+            ),
+            array(
+                'select',
+                array('Key[subkey1][subkey2]', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<select id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" ccm-passed-value="Two" class="form-control"><option value="One" selected="selected">First</option><option value="Two">Second</option></select>',
+                array('Key' => array('subkey1' => array('subkey2' => 'One'))),
+            ),
+            array(
+                'select',
+                array('Key[subkey1][subkey2]', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<select id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" ccm-passed-value="Two" class="form-control"><option value="One">First</option><option value="Two">Second</option></select>',
+                array('Key' => array('subkey1' => array('subkey2' => array('subkey3' => 'One')))),
+            ),
+            // selectMultiple
+            array(
+                'selectMultiple',
+                array('Key', null),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"></select>',
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array()),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"></select>',
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second')),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"><option value="One">First</option><option value="Two">Second</option></select>',
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), false),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"><option value="One">First</option><option value="Two">Second</option></select>',
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), null),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"><option value="One">First</option><option value="Two">Second</option></select>',
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), array()),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"><option value="One">First</option><option value="Two">Second</option></select>',
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), false, array('data-mine' => 'MY DATA', 'class' => 'MY-CLASS')),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" data-mine="MY DATA" class="MY-CLASS form-control"><option value="One">First</option><option value="Two">Second</option></select>',
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"><option value="One">First</option><option value="Two" selected="selected">Second</option></select>',
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), array('Two')),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"><option value="One">First</option><option value="Two" selected="selected">Second</option></select>',
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), array('Invalid')),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"><option value="One">First</option><option value="Two">Second</option></select>',
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), array('Two', 'One')),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"><option value="One" selected="selected">First</option><option value="Two" selected="selected">Second</option></select>',
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second')),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"><option value="One" selected="selected">First</option><option value="Two">Second</option></select>',
+                array('Key' => 'One'),
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second')),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"><option value="One">First</option><option value="Two">Second</option></select>',
+                array('Key' => array()),
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second')),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"><option value="One" selected="selected">First</option><option value="Two">Second</option></select>',
+                array('Key' => array('One')),
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"><option value="One" selected="selected">First</option><option value="Two">Second</option></select>',
+                array('Key' => array('One')),
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second')),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"><option value="One" selected="selected">First</option><option value="Two" selected="selected">Second</option></select>',
+                array('Key' => array('One', 'Two')),
+            ),
+            array(
+                'selectMultiple',
+                array('Key', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<input type="hidden" class="ignore" name="Key" value="" /><select id="Key" name="Key[]" multiple="multiple" class="form-control"><option value="One" selected="selected">First</option><option value="Two" selected="selected">Second</option></select>',
+                array('Key' => array('One', 'Two')),
+            ),
+            array(
+                'selectMultiple',
+                array('Key[subkey1][subkey2]', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<input type="hidden" class="ignore" name="Key[subkey1][subkey2]" value="" /><select id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2][]" multiple="multiple" class="form-control"><option value="One">First</option><option value="Two" selected="selected">Second</option></select>',
+                array('Key' => array('One')),
+            ),
+            array(
+                'selectMultiple',
+                array('Key[subkey1][subkey2]', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<input type="hidden" class="ignore" name="Key[subkey1][subkey2]" value="" /><select id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2][]" multiple="multiple" class="form-control"><option value="One">First</option><option value="Two" selected="selected">Second</option></select>',
+                array('Key' => array('subkey1' => array('One'))),
+            ),
+            array(
+                'selectMultiple',
+                array('Key[subkey1][subkey2]', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<input type="hidden" class="ignore" name="Key[subkey1][subkey2]" value="" /><select id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2][]" multiple="multiple" class="form-control"><option value="One" selected="selected">First</option><option value="Two">Second</option></select>',
+                array('Key' => array('subkey1' => array('subkey2' => array('One')))),
+            ),
+            array(
+                'selectMultiple',
+                array('Key[subkey1][subkey2]', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<input type="hidden" class="ignore" name="Key[subkey1][subkey2]" value="" /><select id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2][]" multiple="multiple" class="form-control"><option value="One" selected="selected">First</option><option value="Two">Second</option></select>',
+                array('Key' => array('subkey1' => array('subkey2' => array('subkey3' => 'One')))),
+            ),
+            array(
+                'selectMultiple',
+                array('Key[subkey1][subkey2]', array('One' => 'First', 'Two' => 'Second'), 'Two'),
+                '<input type="hidden" class="ignore" name="Key[subkey1][subkey2]" value="" /><select id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2][]" multiple="multiple" class="form-control"><option value="One">First</option><option value="Two">Second</option></select>',
+                array('Key' => array('subkey1' => array('subkey2' => array('subkey3' => array('One'))))),
+            ),
+        );
+    }
+    /**
+     * @dataProvider providerTestCreateElements
+     */
+    public function testCreateElements($method, array $args, $expected, array $post = array())
+    {
+        if (!empty($post)) {
+            $_SERVER['REQUEST_METHOD'] = 'POST';
+            foreach ($post as $k => $v) {
+                $_REQUEST[$k] = $v;
+                $_POST[$k] = $v;
+            }
+        }
+        $calculated = call_user_func_array(array(static::$formHelper, $method), $args);
+        if (strpos($expected, '**UNIQUENUMBER**') === false) {
+            $this->assertSame($expected, $calculated);
+        } else {
+            $chunks = explode('**UNIQUENUMBER**', $expected);
+            array_walk($chunks, function (&$chunk, $index) {
+                $chunk = preg_quote($chunk, '/');
+            });
+            $rx = '/^' . implode('\d+', $chunks) . '$/';
+            $this->assertRegExp($rx, $calculated);
+        }
+    }
+}

--- a/web/concrete/src/Form/Service/Form.php
+++ b/web/concrete/src/Form/Service/Form.php
@@ -1,368 +1,416 @@
 <?php
+
 namespace Concrete\Core\Form\Service;
+
 use Loader;
 use View;
 
 /**
- * 
+ * Helpful functions for working with forms. Includes HTML input tags and the like.
+ *
  * @package Helpers
  * @category Concrete
  * @author Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2008 Concrete5. (http://www.concrete5.org)
  * @license    http://www.concrete5.org/license/     MIT License
  */
+class Form
+{
+    private $radioIndex = 1;
+    private $selectIndex = 1;
 
-/**
- * Helpful functions for working with forms. Includes HTML input tags and the like
- * @package Helpers
- * @category Concrete
- * @author Andrew Embler <andrew@concrete5.org>
- * @copyright  Copyright (c) 2003-2008 Concrete5. (http://www.concrete5.org)
- * @license    http://www.concrete5.org/license/     MIT License
- */
+    public function __construct()
+    {
+        $this->th = Loader::helper('text');
+    }
 
-class Form {
-	public $helperAlwaysCreateNewInstance = true;
+    /**
+     * Returns an action suitable for including in a form action property.
+     *
+     * @param string $action
+     * @param string $task
+     */
+    public function action($action, $task = null)
+    {
+        return View::url($action, $task);
+    }
 
-	private $radioIndex = 1;
-	private $selectIndex = 1;
+    /**
+     * Creates a submit button.
+     *
+     * @param string $name
+     * @param string value
+     * @param array $fields Additional fields appended at the end of the submit button
+     * return string $html
+     */
+    public function submit($name, $value, $fields = array(), $additionalClasses = '')
+    {
+        return '<input type="submit"' . $this->parseMiscFields('btn ccm-input-submit ' . $additionalClasses, $fields) . ' id="' . $name . '" name="' . $name . '" value="' . $value . '" />';
+    }
 
-	public function __construct() {
-		$this->th = Loader::helper('text');
-	}
+    /**
+     * Creates a button.
+     *
+     * @param string $name
+     * @param string value
+     * @param array $fields Additional fields appended at the end of the submit button
+     * return string $html
+     */
+    public function button($name, $value, $fields = array(), $additionalClasses = '')
+    {
+        return '<input type="button"' . $this->parseMiscFields('btn ccm-input-button ' . $additionalClasses, $fields) . ' id="' . $name . '" name="' . $name . '" value="' . $value . '" />';
+    }
 
-	/** 
-	 * Returns an action suitable for including in a form action property.
-	 * @param string $action
-	 * @param string $task
-	 */ 
-	public function action($action, $task = null) {
-		return View::url($action, $task);
-	}
+    /**
+     * Creates a label tag.
+     *
+     * @param string $field
+     * @param string $name
+     *
+     * @return string $html
+     */
+    public function label($field, $name, $miscFields = array())
+    {
+        $str = '<label for="' . $field . '"' . $this->parseMiscFields('control-label ', $miscFields) . '>' . $name . '</label>';
 
-	/** 
-	 * Creates a submit button
-	 * @param string $name
-	 * @param string value
-	 * @param array $fields Additional fields appended at the end of the submit button
-	 * return string $html
-	 */	 
-	public function submit($name, $value, $fields = array(), $additionalClasses='') {
-		return '<input type="submit"' . $this->parseMiscFields('btn ccm-input-submit ' . $additionalClasses, $fields) . ' id="' . $name . '" name="' . $name . '" value="' . $value . '" />';
-	}
+        return $str;
+    }
 
-	/** 
-	 * Creates a button
-	 * @param string $name
-	 * @param string value
-	 * @param array $fields Additional fields appended at the end of the submit button
-	 * return string $html
-	 */	 
-	public function button($name, $value, $fields = array(), $additionalClasses='') {
-		return '<input type="button"' . $this->parseMiscFields('btn ccm-input-button ' . $additionalClasses, $fields) . ' id="' . $name . '" name="' . $name . '" value="' . $value . '" />';
-	}
+    /**
+     * Creates a file input element.
+     *
+     * @param string $key
+     */
+    public function file($key)
+    {
+        $str = '<input type="file" id="' . $key . '" name="' . $key . '" value="" class="form-control" />';
 
-	/** 
-	 * Creates a label tag
-	 * @param string $field
-	 * @param string $name
-	 * @return string $html
-	 */
-	public function label($field, $name, $miscFields = array()) {
-		$str = '<label for="' . $field . '"' . $this->parseMiscFields('control-label ', $miscFields) . '>' . $name . '</label>';
-		return $str;
-	}
+        return $str;
+    }
 
-	/** 
-	 * Creates a file input element
-	 * @param string $key
-	 */
-	public function file($key) {
-		$str = '<input type="file" id="' . $key . '" name="' . $key . '" value="" class="form-control" />';
-		return $str;
-	}
+    /**
+     * Creates a hidden form field.
+     *
+     * @param string $key
+     * @param string $value
+     */
+    public function hidden($key, $value = null)
+    {
+        $val = $this->getRequestValue($key);
+        if ($val !== false && (!is_array($val))) {
+            $value = $val;
+        }
+        $str = '<input type="hidden" name="' . $key . '" id="' . $key . '" value="' . $value . '" />';
 
-	/**
-	 * Creates a hidden form field. 
-	 * @param string $key
-	 * @param string $value
-	 */
-	public function hidden($key, $value = null) {
-		$val = $this->getRequestValue($key);
-		if ($val !== false && (!is_array($val))) {
-			$value = $val;
-		}
-		$str = '<input type="hidden" name="' . $key . '" id="' . $key . '" value="' . $value . '" />';
-		return $str;
-	}
+        return $str;
+    }
 
-	/**
-	 * Generates a checkbox
-	 * @param string $key Checkbox's name and id. Should end with "[]" if it's to return an array on submit.
-	 * @param string $value String value sent to server, if checkbox is checked, on submit
-	 * @param string $isChecked "Checked" value (subject to be overridden by $_REQUEST). Checkbox is checked if value is true (string). Note that 'false' (string) evaluates to true (boolean)!
-	 * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
-	 * @return $html
-	 */
-	public function checkbox($key, $value, $isChecked = false, $miscFields = array()) {
-		$id = $key;
-		$_field = $key;
+    /**
+     * Generates a checkbox.
+     *
+     * @param string $key Checkbox's name and id. Should end with "[]" if it's to return an array on submit.
+     * @param string $value String value sent to server, if checkbox is checked, on submit
+     * @param string $isChecked "Checked" value (subject to be overridden by $_REQUEST). Checkbox is checked if value is true (string). Note that 'false' (string) evaluates to true (boolean)!
+     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     *
+     * @return $html
+     */
+    public function checkbox($key, $value, $isChecked = false, $miscFields = array())
+    {
+        $id = $key;
+        $_field = $key;
 
-		if (substr($key, -2) == '[]') {
-			$_field = substr($key, 0, -2);
-			$id = $_field . '_' . $value;
-		}
+        if (substr($key, -2) == '[]') {
+            $_field = substr($key, 0, -2);
+            $id = $_field . '_' . $value;
+        }
 
-		if ($isChecked && (!isset($_REQUEST[$_field])) && ($_SERVER['REQUEST_METHOD'] != 'POST')) {
-			$checked = true;
-		} else if ($this->getRequestValue($key) == $value && $value != false) {
-			$checked = true;
-		} else if (is_array($this->getRequestValue($key)) && in_array($value, $this->getRequestValue($key))) {
-			$checked = true;
-		}
+        if ($isChecked && (!isset($_REQUEST[$_field])) && ($_SERVER['REQUEST_METHOD'] != 'POST')) {
+            $checked = true;
+        } elseif ($this->getRequestValue($key) == $value && $value != false) {
+            $checked = true;
+        } elseif (is_array($this->getRequestValue($key)) && in_array($value, $this->getRequestValue($key))) {
+            $checked = true;
+        }
 
-		if ($checked) {
-			$checked = 'checked="checked" ';
-		}
+        if ($checked) {
+            $checked = 'checked="checked" ';
+        }
 
-		return '<input type="checkbox" '. $this->parseMiscFields('ccm-input-checkbox', $miscFields) . ' name="' . $key . '" id="' . $id . '" value="' . $value . '" ' . $checked . ' />';
-	}
+        return '<input type="checkbox" '. $this->parseMiscFields('ccm-input-checkbox', $miscFields) . ' name="' . $key . '" id="' . $id . '" value="' . $value . '" ' . $checked . ' />';
+    }
 
-	/** 
-	 * Creates a textarea field. Second argument is either the value of the field (and if it's blank we check post) or a misc. array of fields
-	 * @param string $key
-	 * @return string $html
-	 */
-	 public function textarea($key) {
-	 	$a = func_get_args();
+     /**
+      * Creates a textarea field. Second argument is either the value of the field (and if it's blank we check post) or a misc. array of fields.
+      *
+      * @param string $key
+      *
+      * @return string $html
+      */
+     public function textarea($key)
+     {
+         $a = func_get_args();
 
-		$str = '<textarea id="' . $key . '" name="' . $key . '" ';
-		$rv = $this->getRequestValue($key);
+         $str = '<textarea id="' . $key . '" name="' . $key . '" ';
+         $rv = $this->getRequestValue($key);
 
-		if (count($a) == 3) {
-			$innerValue = ($rv !== false) ? $rv : $a[1];
-			$miscFields = $a[2];
-		} else {
-			if (is_array($a[1])) {
-				$innerValue = ($rv !== false) ? $rv : '';
-				$miscFields = $a[1];
-			} else {
-				// we ignore this second value if a post is set with this guy in it
-				$innerValue = ($rv !== false) ? $rv : $a[1];
-			}
-		}
+         if (count($a) == 3) {
+             $innerValue = ($rv !== false) ? $rv : $a[1];
+             $miscFields = $a[2];
+         } else {
+             if (is_array($a[1])) {
+                 $innerValue = ($rv !== false) ? $rv : '';
+                 $miscFields = $a[1];
+             } else {
+                 // we ignore this second value if a post is set with this guy in it
+                $innerValue = ($rv !== false) ? $rv : $a[1];
+             }
+         }
 
-		$str .= $this->parseMiscFields('form-control', $miscFields);
-		$str .= '>' . $innerValue . '</textarea>';
-		return $str;
-	 }
+         $str .= $this->parseMiscFields('form-control', $miscFields);
+         $str .= '>' . $innerValue . '</textarea>';
 
-	/**
-	 * Generates a radio button
-	 * @param string $key
-	 * @param string $valueOfButton
-	 * @param string $valueOfSelectedOption
-	 */
-	public function radio($key, $value, $valueOrArray = false, $miscFields = array()) {
-		$str = '<input type="radio" name="' . $key . '" id="' . $key . $this->radioIndex . '" value="' . $value . '" ';
+         return $str;
+     }
 
-		if (is_array($valueOrArray)) {
-			$miscFields = $valueOrArray;
-		}
+    /**
+     * Generates a radio button.
+     *
+     * @param string $key
+     * @param string $valueOfButton
+     * @param string $valueOfSelectedOption
+     */
+    public function radio($key, $value, $valueOrArray = false, $miscFields = array())
+    {
+        $str = '<input type="radio" name="' . $key . '" id="' . $key . $this->radioIndex . '" value="' . $value . '" ';
 
-		$str .= $this->parseMiscFields('ccm-input-radio', $miscFields) . ' ';
+        if (is_array($valueOrArray)) {
+            $miscFields = $valueOrArray;
+        }
 
-		if ($valueOrArray == $value && !isset($_REQUEST[$key]) || (isset($_REQUEST[$key]) && $_REQUEST[$key] == $value)) {
-			$str .= 'checked="checked" ';
-		}
+        $str .= $this->parseMiscFields('ccm-input-radio', $miscFields) . ' ';
 
-		$this->radioIndex++;
+        if ($valueOrArray == $value && !isset($_REQUEST[$key]) || (isset($_REQUEST[$key]) && $_REQUEST[$key] == $value)) {
+            $str .= 'checked="checked" ';
+        }
 
-		$str .= ' />';
-		return $str;
-	}
+        $this->radioIndex++;
 
-	protected function processRequestValue($key, $type = "post") {
-		$arr = ($type == 'post') ? $_POST : $_GET;
-		if (strpos($key, '[') !== false) {
-			// we've got something like 'akID[34]['value'] here, which we need to get data from
-			
-			/* @var $ah ArrayHelper */
-			$ah = Loader::helper('arrays');
-			$key = str_replace(']', '', $key);
-			$key = explode('[', trim($key, '['));
-			$v2 = $ah->get($arr, $key);
+        $str .= ' />';
 
-			if (isset($v2)) {
-				// if the type if GET, we make sure to strip it of any nasties
-				// POST we will let stay unfiltered
-				if (is_string($v2)) {
-					return $this->th->entities($v2);
-				} else {
-					return $v2;
-				}
-			}
-		} else if (isset($arr[$key])) {
-			return $this->th->entities($arr[$key]);
-		}
+        return $str;
+    }
 
-		return false;
-	}
+    protected function processRequestValue($key, $type = "post")
+    {
+        $arr = ($type == 'post') ? $_POST : $_GET;
+        if (strpos($key, '[') !== false) {
+            // we've got something like 'akID[34]['value'] here, which we need to get data from
 
-	// checks the request based on the key passed. Does things like turn the key into arrays if the key has text versions of [ and ] in it, etc..
-	public function getRequestValue($key) {
-		$val = $this->processRequestValue($key, 'post');
-		if ($val !== false) {
-			return $val;
-		} else {
-			return $this->processRequestValue($key, 'get');
-		}
-	}
+            /* @var $ah ArrayHelper */
+            $ah = Loader::helper('arrays');
+            $key = str_replace(']', '', $key);
+            $key = explode('[', trim($key, '['));
+            $v2 = $ah->get($arr, $key);
 
+            if (isset($v2)) {
+                // if the type if GET, we make sure to strip it of any nasties
+                // POST we will let stay unfiltered
+                if (is_string($v2)) {
+                    return $this->th->entities($v2);
+                } else {
+                    return $v2;
+                }
+            }
+        } elseif (isset($arr[$key])) {
+            return $this->th->entities($arr[$key]);
+        }
 
-	/**
-	 * Internal function that creates an <input> element of type $type. Handles the messiness of evaluating $valueOrArray. Assigns a default class of ccm-input-$type
-	 * @param string $key Input element's name and id
-	 * @param string $type Accepted value for HTML attribute "type"
-	 * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-	 * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
-	 * @return $html
+        return false;
+    }
 
-	 */
-	protected function inputType($key, $type, $valueOrArray, $miscFields) {
-		$val = $this->getRequestValue($key);
+    // checks the request based on the key passed. Does things like turn the key into arrays if the key has text versions of [ and ] in it, etc..
+    public function getRequestValue($key)
+    {
+        $val = $this->processRequestValue($key, 'post');
+        if ($val !== false) {
+            return $val;
+        } else {
+            return $this->processRequestValue($key, 'get');
+        }
+    }
 
-		if (is_array($valueOrArray)) {
-			//valueOrArray is, in fact, the miscFields array
-			$miscFields = $valueOrArray;
-		} else {
-			//valueOrArray is either empty or the default field value; miscFields is either empty or the miscFields
-			$val = ($val !== false) ? $val : $valueOrArray;
-		}
-		$val = str_replace('"', '&#34;', $val);
+    /**
+     * Internal function that creates an <input> element of type $type. Handles the messiness of evaluating $valueOrArray. Assigns a default class of ccm-input-$type.
+     *
+     * @param string $key Input element's name and id
+     * @param string $type Accepted value for HTML attribute "type"
+     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
+     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     *
+     * @return $html
 
-		return "<input id=\"$key\" type=\"$type\" name=\"$key\" value=\"$val\" " . $this->parseMiscFields("form-control ccm-input-$type", $miscFields) . ' />';
-	}
+     */
+    protected function inputType($key, $type, $valueOrArray, $miscFields)
+    {
+        $val = $this->getRequestValue($key);
 
-	/**
-	 * Renders a text input field.
-	 * @param string $key Input element's name and id
-	 * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-	 * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
-	 * @return $html
-	 */
-	public function text($key, $valueOrArray = false, $miscFields = array()) {
-		return $this->inputType($key, 'text', $valueOrArray, $miscFields);
-	}
-	
-	/**
-	* Renders a number input field.
-	* @param string $key Input element's name and id
-	* @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-	* @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
-	* @return $html
-	*/
-	public function number($key, $valueOrArray = false, $miscFields = array()) {
-		return $this->inputType($key, 'number', $valueOrArray, $miscFields);	
-	}
+        if (is_array($valueOrArray)) {
+            //valueOrArray is, in fact, the miscFields array
+            $miscFields = $valueOrArray;
+        } else {
+            //valueOrArray is either empty or the default field value; miscFields is either empty or the miscFields
+            $val = ($val !== false) ? $val : $valueOrArray;
+        }
+        $val = str_replace('"', '&#34;', $val);
 
-	/**
-	 * Renders an email input field.
-	 * @param string $key Input element's name and id
-	 * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-	 * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
-	 * @return $html
-	 */
-	public function email($key, $valueOrArray = false, $miscFields = array()) {
-		return $this->inputType($key, 'email', $valueOrArray, $miscFields);
-	}
-	
-	/**
-	 * Renders a telephone input field.
-	 * @param string $key Input element's name and id
-	 * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-	 * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
-	 * @return $html
-	 */
-	public function telephone($key, $valueOrArray = false, $miscFields = array()) {
-		return $this->inputType($key, 'tel', $valueOrArray, $miscFields);
-	}
+        return "<input id=\"$key\" type=\"$type\" name=\"$key\" value=\"$val\" " . $this->parseMiscFields("form-control ccm-input-$type", $miscFields) . ' />';
+    }
 
-	/**
-	 * Renders a URL input field.
-	 * @param string $key Input element's name and id
-	 * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-	 * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
-	 * @return $html
-	 */
-	public function url($key, $valueOrArray = false, $miscFields = array()) {
-		return $this->inputType($key, 'url', $valueOrArray, $miscFields);
-	}
+    /**
+     * Renders a text input field.
+     *
+     * @param string $key Input element's name and id
+     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
+     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     *
+     * @return $html
+     */
+    public function text($key, $valueOrArray = false, $miscFields = array())
+    {
+        return $this->inputType($key, 'text', $valueOrArray, $miscFields);
+    }
 
-	/**
-	 * Renders a search input field.
-	 * @param string $key Input element's name and id
-	 * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-	 * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
-	 * @return $html
-	 */
-	public function search($key, $valueOrArray = false, $miscFields = array()) {
-		return $this->inputType($key, 'search', $valueOrArray, $miscFields);
-	}
+    /**
+     * Renders a number input field.
+     *
+     * @param string $key Input element's name and id
+     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
+     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     *
+     * @return $html
+     */
+    public function number($key, $valueOrArray = false, $miscFields = array())
+    {
+        return $this->inputType($key, 'number', $valueOrArray, $miscFields);
+    }
 
-	/**
-	 * Renders a select field. First argument is the name of the field. Second is an associative array of key => display. Third argument is either the value of the field to be selected (and if it's blank we check post) or a misc. array of fields
-	 * @param string $key
-	 * @return $html
-	 */
-	public function select($key, $optionValues, $valueOrArray = false, $miscFields = array()) {
-        if(!is_array($optionValues)) {
+    /**
+     * Renders an email input field.
+     *
+     * @param string $key Input element's name and id
+     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
+     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     *
+     * @return $html
+     */
+    public function email($key, $valueOrArray = false, $miscFields = array())
+    {
+        return $this->inputType($key, 'email', $valueOrArray, $miscFields);
+    }
+
+    /**
+     * Renders a telephone input field.
+     *
+     * @param string $key Input element's name and id
+     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
+     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     *
+     * @return $html
+     */
+    public function telephone($key, $valueOrArray = false, $miscFields = array())
+    {
+        return $this->inputType($key, 'tel', $valueOrArray, $miscFields);
+    }
+
+    /**
+     * Renders a URL input field.
+     *
+     * @param string $key Input element's name and id
+     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
+     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     *
+     * @return $html
+     */
+    public function url($key, $valueOrArray = false, $miscFields = array())
+    {
+        return $this->inputType($key, 'url', $valueOrArray, $miscFields);
+    }
+
+    /**
+     * Renders a search input field.
+     *
+     * @param string $key Input element's name and id
+     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
+     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     *
+     * @return $html
+     */
+    public function search($key, $valueOrArray = false, $miscFields = array())
+    {
+        return $this->inputType($key, 'search', $valueOrArray, $miscFields);
+    }
+
+    /**
+     * Renders a select field. First argument is the name of the field. Second is an associative array of key => display. Third argument is either the value of the field to be selected (and if it's blank we check post) or a misc. array of fields.
+     *
+     * @param string $key
+     *
+     * @return $html
+     */
+    public function select($key, $optionValues, $valueOrArray = false, $miscFields = array())
+    {
+        if (!is_array($optionValues)) {
             $optionValues = array();
         }
-		$val = $this->getRequestValue($key);
-		if (is_array($val)) {
-			$valueOrArray = $val[0];
-		}
+        $val = $this->getRequestValue($key);
+        if (is_array($val)) {
+            $valueOrArray = $val[0];
+        }
 
-		if (substr($key, -2) == '[]') {
-			$_key = substr($key, 0, -2);
-			$id = $_key . $this->selectIndex;
-		} else {
-			$_key = $key;
-			$id = $key;
-		}
+        if (substr($key, -2) == '[]') {
+            $_key = substr($key, 0, -2);
+            $id = $_key . $this->selectIndex;
+        } else {
+            $_key = $key;
+            $id = $key;
+        }
 
-		if (is_array($valueOrArray)) {
-			$miscFields = $valueOrArray;
-		} else {
-			$miscFields['ccm-passed-value'] = $valueOrArray;	
-		}
+        if (is_array($valueOrArray)) {
+            $miscFields = $valueOrArray;
+        } else {
+            $miscFields['ccm-passed-value'] = $valueOrArray;
+        }
 
-		$str = '<select name="' . $key . '" id="' . $id . '" ' . $this->parseMiscFields('form-control', $miscFields) . '>';
+        $str = '<select name="' . $key . '" id="' . $id . '" ' . $this->parseMiscFields('form-control', $miscFields) . '>';
 
-		foreach($optionValues as $k => $value) {
-			$selected = "";
-			if ((string)$valueOrArray === (string)$k  && !isset($_REQUEST[$_key]) || ($val !== false && $val == $k) || (is_array($_REQUEST[$_key]) && (in_array($k, $_REQUEST[$_key])))) {
-				$selected = 'selected="selected"';
-			}
-			$str .= '<option value="' . $k . '" ' . $selected . '>' . $value . '</option>';
-		}
+        foreach ($optionValues as $k => $value) {
+            $selected = "";
+            if ((string) $valueOrArray === (string) $k  && !isset($_REQUEST[$_key]) || ($val !== false && $val == $k) || (is_array($_REQUEST[$_key]) && (in_array($k, $_REQUEST[$_key])))) {
+                $selected = 'selected="selected"';
+            }
+            $str .= '<option value="' . $k . '" ' . $selected . '>' . $value . '</option>';
+        }
 
-		$this->selectIndex++;
+        $this->selectIndex++;
 
-		$str .= '</select>';
-		return $str;
-	}
+        $str .= '</select>';
 
-	/**
-	 * Renders a multiple select box
-	 * @param string $key Select's name and id
-	 * @param array $optionValues Hash array with name/value as the select's option value/text
-	 * @param array|string $defaultValues Default value(s) which match with the option values; overridden by $_REQUEST
-	 * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
-	 * @return $html
-	 */
-	public function selectMultiple($key, $optionValues, $defaultValues = false, $miscFields = array()) {
+        return $str;
+    }
+
+    /**
+     * Renders a multiple select box.
+     *
+     * @param string $key Select's name and id
+     * @param array $optionValues Hash array with name/value as the select's option value/text
+     * @param array|string $defaultValues Default value(s) which match with the option values; overridden by $_REQUEST
+     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     *
+     * @return $html
+     */
+    public function selectMultiple($key, $optionValues, $defaultValues = false, $miscFields = array())
+    {
         $val = $this->getRequestValue($key . '[]');
 
         $defaultValues = (array) $defaultValues;
@@ -382,35 +430,40 @@ class Form {
         return $str;
     }
 
-	/**
-	 * Renders a password input field.
-	 * @param string $key Input element's name and id
-	 * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-	 * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
-	 * @return $html
-	 */
-	public function password($key, $valueOrArray = false, $miscFields = array()) {
-		return $this->inputType($key, 'password', $valueOrArray, $miscFields);
-	}
+    /**
+     * Renders a password input field.
+     *
+     * @param string $key Input element's name and id
+     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
+     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     *
+     * @return $html
+     */
+    public function password($key, $valueOrArray = false, $miscFields = array())
+    {
+        return $this->inputType($key, 'password', $valueOrArray, $miscFields);
+    }
 
-	/**
-	 * Create an HTML fragment of attribute values, merging any CSS class names as necessary
-	 * @param string $defaultClass Default CSS class name
-	 * @param array $attributes A hash array of attributes (name => value)
-	 * @return string a fragment of attributes suitable to put inside of an HTML tag
-	 */
-	protected function parseMiscFields($defaultClass, $attributes) {
-		$attr = '';
+    /**
+     * Create an HTML fragment of attribute values, merging any CSS class names as necessary.
+     *
+     * @param string $defaultClass Default CSS class name
+     * @param array $attributes A hash array of attributes (name => value)
+     *
+     * @return string a fragment of attributes suitable to put inside of an HTML tag
+     */
+    protected function parseMiscFields($defaultClass, $attributes)
+    {
+        $attr = '';
 
-		if ($defaultClass) {
-			$attributes['class'] = trim((isset($attributes['class']) ? $attributes['class'] : '') . ' ' . $defaultClass);
-		}
-		
-		foreach ((array) $attributes as $k => $v) {
-			$attr .= " $k=\"$v\"";
-		}
+        if ($defaultClass) {
+            $attributes['class'] = trim((isset($attributes['class']) ? $attributes['class'] : '') . ' ' . $defaultClass);
+        }
 
-		return $attr;
-	}
+        foreach ((array) $attributes as $k => $v) {
+            $attr .= " $k=\"$v\"";
+        }
 
+        return $attr;
+    }
 }

--- a/web/concrete/src/Form/Service/Form.php
+++ b/web/concrete/src/Form/Service/Form.php
@@ -16,12 +16,41 @@ use View;
  */
 class Form
 {
-    private $radioIndex = 1;
-    private $selectIndex = 1;
+    /**
+     * Internal counter used to generate unique IDs for radio inputs with the same name.
+     *
+     * @var int
+     */
+    protected $radioIndex = 1;
 
+    /**
+     * Internal counter used to generate unique IDs for select inputs with the same name.
+     *
+     * @var int
+     */
+    protected $selectIndex = 1;
+
+    /**
+     * Text helper instance.
+     *
+     * @var \Concrete\Core\Utility\Service\Text
+     */
+    protected $th;
+
+    /**
+     * Arrays helper instance.
+     *
+     * @var \Concrete\Core\Utility\Service\Arrays
+     */
+    protected $ah;
+
+    /**
+     * Initialize the instance.
+     */
     public function __construct()
     {
         $this->th = Core::make('helper/text');
+        $this->ah = Core::make('helper/arrays');
     }
 
     /**
@@ -38,362 +67,392 @@ class Form
     /**
      * Creates a submit button.
      *
-     * @param string $key
-     * @param string value
-     * @param array $fields Additional fields appended at the end of the submit button
-     * return string $html
+     * @param string $key The name/id of the element.
+     * @param string value The value of the element.
+     * @param array $miscFields Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     * @param string $additionalClasses List of additional space-separated CSS class names.
+     *
+     * @return string
      */
-    public function submit($key, $value, $fields = array(), $additionalClasses = '')
+    public function submit($key, $value, $miscFields = array(), $additionalClasses = '')
     {
-        return '<input type="submit"' . $this->parseMiscFields('btn ccm-input-submit ' . $additionalClasses, $fields) . ' id="' . $key . '" name="' . $key . '" value="' . $value . '" />';
+        return '<input type="submit"' . $this->parseMiscFields('btn ccm-input-submit ' . $additionalClasses, $miscFields) . ' id="' . $key . '" name="' . $key . '" value="' . $value . '" />';
     }
 
     /**
      * Creates a button.
      *
-     * @param string $key
-     * @param string value
-     * @param array $fields Additional fields appended at the end of the submit button
-     * return string $html
+     * @param string $key The name/id of the element.
+     * @param string value The value of the element.
+     * @param array $miscFields Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     * @param string $additionalClasses List of additional space-separated CSS class names.
+     *
+     * @return string
      */
-    public function button($key, $value, $fields = array(), $additionalClasses = '')
+    public function button($key, $value, $miscFields = array(), $additionalClasses = '')
     {
-        return '<input type="button"' . $this->parseMiscFields('btn ccm-input-button ' . $additionalClasses, $fields) . ' id="' . $key . '" name="' . $key . '" value="' . $value . '" />';
+        return '<input type="button"' . $this->parseMiscFields('btn ccm-input-button ' . $additionalClasses, $miscFields) . ' id="' . $key . '" name="' . $key . '" value="' . $value . '" />';
     }
 
     /**
      * Creates a label tag.
      *
-     * @param string $field
-     * @param string $name
+     * @param string $forFieldID The id of the associated element.
+     * @param string $innerHTML The inner html of the label.
+     * @param array $miscFields Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
      *
-     * @return string $html
+     * @return string
      */
-    public function label($field, $name, $miscFields = array())
+    public function label($forFieldID, $innerHTML, $miscFields = array())
     {
-        $str = '<label for="' . $field . '"' . $this->parseMiscFields('control-label ', $miscFields) . '>' . $name . '</label>';
-
-        return $str;
+        return '<label for="' . $forFieldID . '"' . $this->parseMiscFields('control-label ', $miscFields) . '>' . $innerHTML . '</label>';
     }
 
     /**
      * Creates a file input element.
      *
-     * @param string $key
+     * @param string $key The name/id of the element.
+     * @param array $miscFields Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     *
+     * @return string
      */
-    public function file($key)
+    public function file($key, $miscFields = array())
     {
-        $str = '<input type="file" id="' . $key . '" name="' . $key . '" value="" class="form-control" />';
-
-        return $str;
+        return '<input type="file" id="' . $key . '" name="' . $key . '" value=""' . $this->parseMiscFields('form-control', $miscFields) . ' />';
     }
 
     /**
      * Creates a hidden form field.
      *
-     * @param string $key
-     * @param string $value
+     * @param string $key The name/id of the element.
+     * @param string $value The value of the element (overriden if we received some data in POST or GET).
+     * @param array $miscFields Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     *
+     * @return string
      */
-    public function hidden($key, $value = null)
+    public function hidden($key, $value = null, $miscFields = array())
     {
-        $val = $this->getRequestValue($key);
-        if ($val !== false && (!is_array($val))) {
-            $value = $val;
+        $requestValue = $this->getRequestValue($key);
+        if ($requestValue !== false && (!is_array($requestValue))) {
+            $value = $requestValue;
         }
-        $str = '<input type="hidden" name="' . $key . '" id="' . $key . '" value="' . $value . '" />';
 
-        return $str;
+        return '<input type="hidden" id="' . $key . '" name="' . $key . '"' . $this->parseMiscFields('', $miscFields) . ' value="' . $value . '" />';
     }
 
     /**
      * Generates a checkbox.
      *
-     * @param string $key Checkbox's name and id. Should end with "[]" if it's to return an array on submit.
+     * @param string $key The name/id of the element. It should end with '[]' if it's to return an array on submit.
      * @param string $value String value sent to server, if checkbox is checked, on submit
      * @param string $isChecked "Checked" value (subject to be overridden by $_REQUEST). Checkbox is checked if value is true (string). Note that 'false' (string) evaluates to true (boolean)!
-     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     * @param array $miscFields Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
      *
-     * @return $html
+     * @return string
      */
     public function checkbox($key, $value, $isChecked = false, $miscFields = array())
     {
-        $id = $key;
-        $_field = $key;
-
         if (substr($key, -2) == '[]') {
             $_field = substr($key, 0, -2);
             $id = $_field . '_' . $value;
+        } else {
+            $_field = $key;
+            $id = $key;
         }
 
+        $checked = false;
         if ($isChecked && (!isset($_REQUEST[$_field])) && ($_SERVER['REQUEST_METHOD'] != 'POST')) {
             $checked = true;
-        } elseif ($this->getRequestValue($key) == $value && $value != false) {
-            $checked = true;
-        } elseif (is_array($this->getRequestValue($key)) && in_array($value, $this->getRequestValue($key))) {
-            $checked = true;
+        } else {
+            $requestValue = $this->getRequestValue($key);
+            if ($requestValue !== false) {
+                if (is_array($requestValue)) {
+                    if (in_array($value, $requestValue)) {
+                        $checked = true;
+                    }
+                } elseif ($requestValue == $value) {
+                    $checked = true;
+                }
+            }
         }
+        $checked = $checked ? ' checked="checked"' : '';
 
-        if ($checked) {
-            $checked = 'checked="checked" ';
-        }
-
-        return '<input type="checkbox" '. $this->parseMiscFields('ccm-input-checkbox', $miscFields) . ' name="' . $key . '" id="' . $id . '" value="' . $value . '" ' . $checked . ' />';
+        return '<input type="checkbox" id="' . $id . '" name="' . $key . '"'. $this->parseMiscFields('ccm-input-checkbox', $miscFields) . ' value="' . $value . '"' . $checked . ' />';
     }
 
      /**
-      * Creates a textarea field. Second argument is either the value of the field (and if it's blank we check post) or a misc. array of fields.
+      * Creates a textarea field.
       *
-      * @param string $key
+      * @param string $key The name/id of the element.
+      * @param string|array $valueOrMiscFields The value of the element or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+      * @param array $miscFields (used if $valueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
       *
-      * @return string $html
+      * @return string
       */
-     public function textarea($key)
+     public function textarea($key, $valueOrMiscFields = '', $miscFields = array())
      {
-         $a = func_get_args();
-
-         $str = '<textarea id="' . $key . '" name="' . $key . '" ';
-         $rv = $this->getRequestValue($key);
-
-         if (count($a) == 3) {
-             $innerValue = ($rv !== false) ? $rv : $a[1];
-             $miscFields = $a[2];
+         if (is_array($valueOrMiscFields)) {
+             $value = '';
+             $miscFields = $valueOrMiscFields;
          } else {
-             if (is_array($a[1])) {
-                 $innerValue = ($rv !== false) ? $rv : '';
-                 $miscFields = $a[1];
-             } else {
-                 // we ignore this second value if a post is set with this guy in it
-                $innerValue = ($rv !== false) ? $rv : $a[1];
-             }
+             $value = $valueOrMiscFields;
+         }
+         $requestValue = $this->getRequestValue($key);
+         if (is_string($requestValue)) {
+             $value = $requestValue;
          }
 
-         $str .= $this->parseMiscFields('form-control', $miscFields);
-         $str .= '>' . $innerValue . '</textarea>';
-
-         return $str;
+         return '<textarea id="' . $key . '" name="' . $key . '"' . $this->parseMiscFields('form-control', $miscFields) . '>' . $value . '</textarea>';
      }
 
     /**
      * Generates a radio button.
      *
-     * @param string $key
-     * @param string $valueOfButton
-     * @param string $valueOfSelectedOption
+     * @param string $key The name of the element (its id will start with $key but will have a progressive unique number added).
+     * @param string $value The value of the radio button.
+     * @param string|array $valueOrMiscFields The value of the element (if it should be initially checked) or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     * @param array $miscFields (used if $valueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     *
+     * @return string
      */
-    public function radio($key, $value, $valueOrArray = false, $miscFields = array())
+    public function radio($key, $value, $checkedValueOrMiscFields = '', $miscFields = array())
     {
-        $str = '<input type="radio" name="' . $key . '" id="' . $key . $this->radioIndex . '" value="' . $value . '" ';
-
-        if (is_array($valueOrArray)) {
-            $miscFields = $valueOrArray;
+        if (is_array($checkedValueOrMiscFields)) {
+            $checkedValue = '';
+            $miscFields = $checkedValueOrMiscFields;
+        } else {
+            $checkedValue = $checkedValueOrMiscFields;
         }
-
-        $str .= $this->parseMiscFields('ccm-input-radio', $miscFields) . ' ';
-
-        if ($valueOrArray == $value && !isset($_REQUEST[$key]) || (isset($_REQUEST[$key]) && $_REQUEST[$key] == $value)) {
-            $str .= 'checked="checked" ';
+        $checked = false;
+        if (isset($_REQUEST[$key])) {
+            if ($_REQUEST[$key] == $value) {
+                $checked = true;
+            }
+        } else {
+            if ($checkedValue == $value) {
+                $checked = true;
+            }
         }
-
-        $this->radioIndex++;
-
+        $str = '<input type="radio" id="' . $key . $this->radioIndex . '" name="' . $key . '" value="' . $value . '"';
+        $str .= $this->parseMiscFields('ccm-input-radio', $miscFields);
+        if ($checked) {
+            $str .= ' checked="checked"';
+        }
         $str .= ' />';
+        $this->radioIndex++;
 
         return $str;
     }
 
-    protected function processRequestValue($key, $type = "post")
+    /**
+     * Checks the request based on the key passed.
+     * If $key denotes an array (eg akID[34]['value']) we'll turn the key into arrays if the key has text versions of [ and ] in it
+     * If the result is a string, it'll be escaped (with htmlspecialchars).
+     *
+     * @param string $key The name of the field to be checked.
+     * @param string $type 'post' to check in POST data, other values to check in GET data.
+     *
+     * @return false|array|string Returns an array if $key denotes an array and we received that data, a string if $key is the name of a received data, false if $key is not found in the received data.
+     */
+    protected function processRequestValue($key, $type = 'post')
     {
         $arr = ($type == 'post') ? $_POST : $_GET;
         if (strpos($key, '[') !== false) {
-            // we've got something like 'akID[34]['value'] here, which we need to get data from
-
-            /* @var $ah ArrayHelper */
-            $ah = Core::make('helper/arrays');
             $key = str_replace(']', '', $key);
             $key = explode('[', trim($key, '['));
-            $v2 = $ah->get($arr, $key);
-
+            $v2 = $this->ah->get($arr, $key);
             if (isset($v2)) {
-                // if the type if GET, we make sure to strip it of any nasties
-                // POST we will let stay unfiltered
                 if (is_string($v2)) {
-                    return $this->th->entities($v2);
+                    return $this->th->specialchars($v2);
                 } else {
                     return $v2;
                 }
             }
-        } elseif (isset($arr[$key])) {
-            return $this->th->entities($arr[$key]);
+        } elseif (isset($arr[$key]) && is_string($arr[$key])) {
+            return $this->th->specialchars($arr[$key]);
         }
 
         return false;
     }
 
-    // checks the request based on the key passed. Does things like turn the key into arrays if the key has text versions of [ and ] in it, etc..
+    /**
+     * Checks the request (first POST then GET) based on the key passed.
+     * If $key denotes an array (eg akID[34]['value']) we'll turn the key into arrays if the key has text versions of [ and ] in it
+     * If the result is a string, it'll be escaped (with htmlspecialchars).
+     *
+     * @param string $key The name of the field to be checked.
+     * @param string $type 'post' to check in POST data, other values to check in GET data.
+     *
+     * @return false|array|string Returns an array if $key denotes an array and we received that data, a string if $key is the name of a received data, false if $key is not found in the received data.
+     */
     public function getRequestValue($key)
     {
-        $val = $this->processRequestValue($key, 'post');
-        if ($val !== false) {
-            return $val;
-        } else {
-            return $this->processRequestValue($key, 'get');
+        $result = $this->processRequestValue($key, 'post');
+        if ($result === false) {
+            $result = $this->processRequestValue($key, 'get');
         }
+
+        return $result;
     }
 
     /**
-     * Internal function that creates an <input> element of type $type. Handles the messiness of evaluating $valueOrArray. Assigns a default class of ccm-input-$type.
+     * Internal function that creates an <input> element of type $type. Handles the messiness of evaluating $valueOrMiscFields. Assigns a default class of ccm-input-$type.
      *
-     * @param string $key Input element's name and id
+     * @param string $key The name/id of the element.
      * @param string $type Accepted value for HTML attribute "type"
-     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     * @param string|array $valueOrMiscFields The value of the element or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     * @param array $miscFields (used if $valueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
      *
-     * @return $html
+     * @return string
 
      */
-    protected function inputType($key, $type, $valueOrArray, $miscFields)
+    protected function inputType($key, $type, $valueOrMiscFields, $miscFields)
     {
-        $val = $this->getRequestValue($key);
-
-        if (is_array($valueOrArray)) {
-            //valueOrArray is, in fact, the miscFields array
-            $miscFields = $valueOrArray;
+        if (is_array($valueOrMiscFields)) {
+            $value = '';
+            $miscFields = $valueOrMiscFields;
         } else {
-            //valueOrArray is either empty or the default field value; miscFields is either empty or the miscFields
-            $val = ($val !== false) ? $val : $valueOrArray;
+            $value = $valueOrMiscFields;
         }
-        $val = str_replace('"', '&#34;', $val);
+        $requestValue = $this->getRequestValue($key);
+        if (is_string($requestValue)) {
+            $value = $requestValue;
+        }
+        $value = str_replace('"', '&#34;', $value);
 
-        return "<input id=\"$key\" type=\"$type\" name=\"$key\" value=\"$val\" " . $this->parseMiscFields("form-control ccm-input-$type", $miscFields) . ' />';
+        return "<input type=\"$type\" id=\"$key\" name=\"$key\" value=\"$value\"" . $this->parseMiscFields("form-control ccm-input-$type", $miscFields) . ' />';
     }
 
     /**
      * Renders a text input field.
      *
-     * @param string $key Input element's name and id
-     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     * @param string $key The name/id of the element.
+     * @param string|array $valueOrMiscFields The value of the element or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     * @param array $miscFields (used if $valueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
      *
-     * @return $html
+     * @return string
      */
-    public function text($key, $valueOrArray = false, $miscFields = array())
+    public function text($key, $valueOrMiscFields = '', $miscFields = array())
     {
-        return $this->inputType($key, 'text', $valueOrArray, $miscFields);
+        return $this->inputType($key, 'text', $valueOrMiscFields, $miscFields);
     }
 
     /**
      * Renders a number input field.
      *
-     * @param string $key Input element's name and id
-     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     * @param string $key The name/id of the element.
+     * @param string|array $valueOrMiscFields The value of the element or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     * @param array $miscFields (used if $valueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
      *
-     * @return $html
+     * @return string
      */
-    public function number($key, $valueOrArray = false, $miscFields = array())
+    public function number($key, $valueOrMiscFields = '', $miscFields = array())
     {
-        return $this->inputType($key, 'number', $valueOrArray, $miscFields);
+        return $this->inputType($key, 'number', $valueOrMiscFields, $miscFields);
     }
 
     /**
      * Renders an email input field.
      *
-     * @param string $key Input element's name and id
-     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     * @param string $key The name/id of the element.
+     * @param string|array $valueOrMiscFields The value of the element or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     * @param array $miscFields (used if $valueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
      *
-     * @return $html
+     * @return string
      */
-    public function email($key, $valueOrArray = false, $miscFields = array())
+    public function email($key, $valueOrMiscFields = '', $miscFields = array())
     {
-        return $this->inputType($key, 'email', $valueOrArray, $miscFields);
+        return $this->inputType($key, 'email', $valueOrMiscFields, $miscFields);
     }
 
     /**
      * Renders a telephone input field.
      *
-     * @param string $key Input element's name and id
-     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     * @param string $key The name/id of the element.
+     * @param string|array $valueOrMiscFields The value of the element or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     * @param array $miscFields (used if $valueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
      *
-     * @return $html
+     * @return string
      */
-    public function telephone($key, $valueOrArray = false, $miscFields = array())
+    public function telephone($key, $valueOrMiscFields = '', $miscFields = array())
     {
-        return $this->inputType($key, 'tel', $valueOrArray, $miscFields);
+        return $this->inputType($key, 'tel', $valueOrMiscFields, $miscFields);
     }
 
     /**
      * Renders a URL input field.
      *
-     * @param string $key Input element's name and id
-     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     * @param string $key The name/id of the element.
+     * @param string|array $valueOrMiscFields The value of the element or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     * @param array $miscFields (used if $valueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
      *
-     * @return $html
+     * @return string
      */
-    public function url($key, $valueOrArray = false, $miscFields = array())
+    public function url($key, $valueOrMiscFields = '', $miscFields = array())
     {
-        return $this->inputType($key, 'url', $valueOrArray, $miscFields);
+        return $this->inputType($key, 'url', $valueOrMiscFields, $miscFields);
     }
 
     /**
      * Renders a search input field.
      *
-     * @param string $key Input element's name and id
-     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     * @param string $key The name/id of the element.
+     * @param string|array $valueOrMiscFields The value of the element or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     * @param array $miscFields (used if $valueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
      *
-     * @return $html
+     * @return string
      */
-    public function search($key, $valueOrArray = false, $miscFields = array())
+    public function search($key, $valueOrMiscFields = '', $miscFields = array())
     {
-        return $this->inputType($key, 'search', $valueOrArray, $miscFields);
+        return $this->inputType($key, 'search', $valueOrMiscFields, $miscFields);
     }
 
     /**
-     * Renders a select field. First argument is the name of the field. Second is an associative array of key => display. Third argument is either the value of the field to be selected (and if it's blank we check post) or a misc. array of fields.
+     * Renders a select field.
      *
-     * @param string $key
+     * @param string $key The name of the element. If $key denotes an array, the ID will start with $key but will have a progressive unique number added; if $key does not denotes an array, the ID attribute will be $key.
+     * @param array $optionValues An associative array of key => display.
+     * @param string|array $valueOrMiscFields The value of the field to be selected or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     * @param array $miscFields (used if $valueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
      *
      * @return $html
      */
-    public function select($key, $optionValues, $valueOrArray = false, $miscFields = array())
+    public function select($key, $optionValues, $valueOrMiscFields = '', $miscFields = array())
     {
         if (!is_array($optionValues)) {
             $optionValues = array();
         }
-        $val = $this->getRequestValue($key);
-        if (is_array($val)) {
-            $valueOrArray = $val[0];
+        if (is_array($valueOrMiscFields)) {
+            $selectedValue = '';
+            $miscFields = $valueOrMiscFields;
+        } else {
+            $selectedValue = (string) $valueOrMiscFields;
         }
-
+        if ($selectedValue !== '') {
+            $miscFields['ccm-passed-value'] = $selectedValue;
+        }
+        $requestValue = $this->getRequestValue($key);
+        if (is_array($requestValue) && isset($requestValue[0]) && is_string($requestValue[0])) {
+            $selectedValue = (string) $requestValue[0];
+        } elseif ($requestValue !== false) {
+            $selectedValue = (string) $requestValue;
+        }
         if (substr($key, -2) == '[]') {
             $_key = substr($key, 0, -2);
             $id = $_key . $this->selectIndex;
+            $this->selectIndex++;
         } else {
             $_key = $key;
             $id = $key;
         }
-
-        if (is_array($valueOrArray)) {
-            $miscFields = $valueOrArray;
-        } else {
-            $miscFields['ccm-passed-value'] = $valueOrArray;
-        }
-
-        $str = '<select name="' . $key . '" id="' . $id . '" ' . $this->parseMiscFields('form-control', $miscFields) . '>';
-
-        foreach ($optionValues as $k => $value) {
-            $selected = "";
-            if ((string) $valueOrArray === (string) $k  && !isset($_REQUEST[$_key]) || ($val !== false && $val == $k) || (is_array($_REQUEST[$_key]) && (in_array($k, $_REQUEST[$_key])))) {
-                $selected = 'selected="selected"';
+        $str = '<select id="' . $id . '" name="' . $key . '"' . $this->parseMiscFields('form-control', $miscFields) . '>';
+        foreach ($optionValues as $k => $text) {
+            $str .= '<option value="' . $k . '"';
+            if ((string) $k === (string) $selectedValue) {
+                $str .= ' selected="selected"';
             }
-            $str .= '<option value="' . $k . '" ' . $selected . '>' . $value . '</option>';
+            $str .= '>' . $text . '</option>';
         }
-
-        $this->selectIndex++;
-
         $str .= '</select>';
 
         return $str;
@@ -402,28 +461,39 @@ class Form
     /**
      * Renders a multiple select box.
      *
-     * @param string $key Select's name and id
+     * @param string $key The ID of the element. The name attribute will be $key followed by '[].
      * @param array $optionValues Hash array with name/value as the select's option value/text
      * @param array|string $defaultValues Default value(s) which match with the option values; overridden by $_REQUEST
-     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     * @param array $miscFields Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
      *
      * @return $html
      */
     public function selectMultiple($key, $optionValues, $defaultValues = false, $miscFields = array())
     {
-        $val = $this->getRequestValue($key . '[]');
-
-        $defaultValues = (array) $defaultValues;
-
-        if ($val) {
-            $defaultValues = $val;
+        $requestValue = $this->getRequestValue($key . '[]');
+        if ($requestValue !== false) {
+            $selectedValues = $requestValue;
+        } else {
+            $selectedValues = $defaultValues;
         }
-
-        $str = "<input type='hidden' class='ignore' name='{$key}' value='' />
-                <select name=\"{$key}[]\" id=\"$key\" multiple=\"multiple\"" . $this->parseMiscFields('form-control', $miscFields) . ">";
-        foreach ($optionValues as $val => $text) {
-            $selected = in_array($val, $defaultValues) ? ' selected="selected"' : '';
-            $str .= "<option value=\"$val\"$selected>$text</option>";
+        if (!is_array($selectedValues)) {
+            if (isset($selectedValues) && ($selectedValues !== false)) {
+                $selectedValues = (array) $selectedValues;
+            } else {
+                $selectedValues = array();
+            }
+        }
+        if (!is_array($optionValues)) {
+            $optionValues = array();
+        }
+        $str = "<input type=\"hidden\" class=\"ignore\" name=\"$key\" value=\"\" />";
+        $str .= "<select id=\"$key\" name=\"{$key}[]\" multiple=\"multiple\"" . $this->parseMiscFields('form-control', $miscFields) . ">";
+        foreach ($optionValues as $k => $text) {
+            $str .= '<option value="' . $k . '"';
+            if (in_array($k, $selectedValues)) {
+                $str .= ' selected="selected"';
+            }
+            $str .= '>' . $text . '</option>';
         }
         $str .= "</select>";
 
@@ -433,34 +503,33 @@ class Form
     /**
      * Renders a password input field.
      *
-     * @param string $key Input element's name and id
-     * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
-     * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+     * @param string $key The name/id of the element.
+     * @param string|array $valueOrMiscFields The value of the element or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
+     * @param array $miscFields (used if $valueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class'.
      *
-     * @return $html
+     * @return string
      */
-    public function password($key, $valueOrArray = false, $miscFields = array())
+    public function password($key, $valueOrMiscFields = '', $miscFields = array())
     {
-        return $this->inputType($key, 'password', $valueOrArray, $miscFields);
+        return $this->inputType($key, 'password', $valueOrMiscFields, $miscFields);
     }
 
     /**
      * Create an HTML fragment of attribute values, merging any CSS class names as necessary.
      *
      * @param string $defaultClass Default CSS class name
-     * @param array $attributes A hash array of attributes (name => value)
+     * @param array $attributes A hash array of attributes (name => value), possibly including 'class'.
      *
-     * @return string a fragment of attributes suitable to put inside of an HTML tag
+     * @return string A fragment of attributes suitable to put inside of an HTML tag
      */
     protected function parseMiscFields($defaultClass, $attributes)
     {
-        $attr = '';
-
+        $attributes = (array) $attributes;
         if ($defaultClass) {
             $attributes['class'] = trim((isset($attributes['class']) ? $attributes['class'] : '') . ' ' . $defaultClass);
         }
-
-        foreach ((array) $attributes as $k => $v) {
+        $attr = '';
+        foreach ($attributes as $k => $v) {
             $attr .= " $k=\"$v\"";
         }
 

--- a/web/concrete/src/Form/Service/Form.php
+++ b/web/concrete/src/Form/Service/Form.php
@@ -2,7 +2,7 @@
 
 namespace Concrete\Core\Form\Service;
 
-use Loader;
+use Core;
 use View;
 
 /**
@@ -21,7 +21,7 @@ class Form
 
     public function __construct()
     {
-        $this->th = Loader::helper('text');
+        $this->th = Core::make('helper/text');
     }
 
     /**
@@ -208,7 +208,7 @@ class Form
             // we've got something like 'akID[34]['value'] here, which we need to get data from
 
             /* @var $ah ArrayHelper */
-            $ah = Loader::helper('arrays');
+            $ah = Core::make('helper/arrays');
             $key = str_replace(']', '', $key);
             $key = explode('[', trim($key, '['));
             $v2 = $ah->get($arr, $key);

--- a/web/concrete/src/Form/Service/Form.php
+++ b/web/concrete/src/Form/Service/Form.php
@@ -38,27 +38,27 @@ class Form
     /**
      * Creates a submit button.
      *
-     * @param string $name
+     * @param string $key
      * @param string value
      * @param array $fields Additional fields appended at the end of the submit button
      * return string $html
      */
-    public function submit($name, $value, $fields = array(), $additionalClasses = '')
+    public function submit($key, $value, $fields = array(), $additionalClasses = '')
     {
-        return '<input type="submit"' . $this->parseMiscFields('btn ccm-input-submit ' . $additionalClasses, $fields) . ' id="' . $name . '" name="' . $name . '" value="' . $value . '" />';
+        return '<input type="submit"' . $this->parseMiscFields('btn ccm-input-submit ' . $additionalClasses, $fields) . ' id="' . $key . '" name="' . $key . '" value="' . $value . '" />';
     }
 
     /**
      * Creates a button.
      *
-     * @param string $name
+     * @param string $key
      * @param string value
      * @param array $fields Additional fields appended at the end of the submit button
      * return string $html
      */
-    public function button($name, $value, $fields = array(), $additionalClasses = '')
+    public function button($key, $value, $fields = array(), $additionalClasses = '')
     {
-        return '<input type="button"' . $this->parseMiscFields('btn ccm-input-button ' . $additionalClasses, $fields) . ' id="' . $name . '" name="' . $name . '" value="' . $value . '" />';
+        return '<input type="button"' . $this->parseMiscFields('btn ccm-input-button ' . $additionalClasses, $fields) . ' id="' . $key . '" name="' . $key . '" value="' . $value . '" />';
     }
 
     /**


### PR DESCRIPTION
Here's a pull request that I've wanted to do since the first time I met concrete5 :wink:
Novice users that take a look at the FormHelper code get confused very fast (it's still happening to me).

So, I simplified almost everything, and added correct phpDoc comments. Furthermore I gave a more meaningful name to some parameters (for instance: `$valueOrMiscFields` instead of `$valueOrArray`).

I also added a lot of tests to check the new code. Everything's working as expected.

As an extra check, I ran all the tests included in this pull request against the old code, and here's the few differences between the old and the new code:

1. in [a textarea test](https://github.com/concrete5/concrete5-5.7.0/commit/fe24c8d14bc0600bf2600f9d52264f6950005ec6#diff-71fea021526964db059d893ddb68f000R407) the old code prints out `<textarea ...>Array</textarea>` because it receives an array and considers it as if it were a string; the new code uses the initial value in this case
2. the same difference exists also for [an input type=text test](https://github.com/concrete5/concrete5-5.7.0/commit/fe24c8d14bc0600bf2600f9d52264f6950005ec6#diff-71fea021526964db059d893ddb68f000R571)
3. the old code fails [a select test](https://github.com/concrete5/concrete5-5.7.0/commit/fe24c8d14bc0600bf2600f9d52264f6950005ec6#diff-71fea021526964db059d893ddb68f000R659): it generates two selected `<option>`s even if the `<select>` is not multiple. I guess this is due to [a really messy and confusing code](https://github.com/concrete5/concrete5-5.7.0/blob/a71b9097818437ed3ff452b478d6e97fb1c64547/web/concrete/src/Form/Service/Form.php#L342) that [I simplified a lot](https://github.com/concrete5/concrete5-5.7.0/commit/1af01dea010ae9dd9f8845e4078be2199d98ea28#diff-8415a178e4e8660939f613db906d4564R451), fixing this problem.
4. The old code aborts the execution during a [selectMultiple test](https://github.com/concrete5/concrete5-5.7.0/commit/fe24c8d14bc0600bf2600f9d52264f6950005ec6?diff=unified#diff-71fea021526964db059d893ddb68f000R674) because it doesn't check if a function parameter is an array. The new code works as expected.
5. The old code aborts the execution during a [selectMultiple test](https://github.com/concrete5/concrete5-5.7.0/commit/fe24c8d14bc0600bf2600f9d52264f6950005ec6?diff=unified#diff-71fea021526964db059d893ddb68f000R727) because it doesn't check if the data received in POST is an array. The new code works as expected.