### PR TITLE
Fix get_image_data

### DIFF
--- a/web/concrete/tools/dashboard/get_image_data.php
+++ b/web/concrete/tools/dashboard/get_image_data.php
@@ -3,7 +3,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 session_write_close();
 
 // first, we check to see if the dashboard image data has been set in the cache
-if (DASHBOARD_BACKGROUND_INFO != false) {
+if (Config::get('concrete.urls.background_info')) {
 	if ($_REQUEST['image'] && preg_match('/([0-9]+)\.jpg/i', $_REQUEST['image'])) {
         /** @var \Stash\Interfaces\ItemInterface $imageDataCache */
         $imageDataCache = Core::make('cache')->getItem('dashboard_image_data/' . $_REQUEST['image']);

--- a/web/concrete/tools/dashboard/get_image_data.php
+++ b/web/concrete/tools/dashboard/get_image_data.php
@@ -1,23 +1,23 @@
-<?
+<?php
+
 defined('C5_EXECUTE') or die("Access Denied.");
 session_write_close();
 
 // first, we check to see if the dashboard image data has been set in the cache
 if (Config::get('concrete.urls.background_info')) {
-	if ($_REQUEST['image'] && preg_match('/([0-9]+)\.jpg/i', $_REQUEST['image'])) {
+    if ($_REQUEST['image'] && preg_match('/([0-9]+)\.jpg/i', $_REQUEST['image'])) {
         /** @var \Stash\Interfaces\ItemInterface $imageDataCache */
         $imageDataCache = Core::make('cache')->getItem('dashboard_image_data/' . $_REQUEST['image']);
-		if ($imageDataCache->isMiss()) {
-			// call out to the server to grab the data
+        if ($imageDataCache->isMiss()) {
+            // call out to the server to grab the data
             $imageDataCache->lock();
-			$cfToken = Marketplace::getSiteToken();
+            $cfToken = Marketplace::getSiteToken();
             $imageData = Loader::helper('file')->getContents(Config::get('concrete.urls.background_info') . '?image=' . $_REQUEST['image'] . '&cfToken=' . $cfToken);
             $imageDataCache->set($imageData);
-		} else {
+        } else {
             $imageData = $imageDataCache->get();
         }
-	}
+    }
 
-	print $imageData;
-
+    print $imageData;
 }

--- a/web/concrete/tools/dashboard/get_image_data.php
+++ b/web/concrete/tools/dashboard/get_image_data.php
@@ -5,19 +5,23 @@ session_write_close();
 
 // first, we check to see if the dashboard image data has been set in the cache
 if (Config::get('concrete.urls.background_info')) {
-    if ($_REQUEST['image'] && preg_match('/([0-9]+)\.jpg/i', $_REQUEST['image'])) {
+    if (isset($_REQUEST['image']) && is_string($_REQUEST['image']) && preg_match('/([0-9]+)\.jpg/i', $_REQUEST['image'])) {
         /** @var \Stash\Interfaces\ItemInterface $imageDataCache */
         $imageDataCache = Core::make('cache')->getItem('dashboard_image_data/' . $_REQUEST['image']);
         if ($imageDataCache->isMiss()) {
             // call out to the server to grab the data
             $imageDataCache->lock();
             $cfToken = Marketplace::getSiteToken();
-            $imageData = Loader::helper('file')->getContents(Config::get('concrete.urls.background_info') . '?image=' . $_REQUEST['image'] . '&cfToken=' . $cfToken);
+            $imageDataUrl = Config::get('concrete.urls.background_info');
+            $imageDataUrl .= (strpos($imageDataUrl, '?') === false) ? '?' : '&';
+            $imageDataUrl .= 'image=' . $_REQUEST['image'] . '&cfToken=' . $cfToken;
+            $imageData = Core::make('helper/file')->getContents($imageDataUrl);
             $imageDataCache->set($imageData);
         } else {
             $imageData = $imageDataCache->get();
         }
+        if ($imageData !== false) {
+            print $imageData;
+        }
     }
-
-    print $imageData;
 }


### PR DESCRIPTION
- The constant `DASHBOARD_BACKGROUND_INFO` was moved to `concrete.urls.background_info` config key
- Support cases when `concrete.urls.background_info` already contains a question mark
- print out `$imageData` only if it's defined