### PR TITLE
Add config setting to enable / disable help system

### DIFF
--- a/web/concrete/config/concrete.php
+++ b/web/concrete/config/concrete.php
@@ -499,7 +499,7 @@ return array(
          *
          * @var bool
          */
-        'display_help_system' => false
+        'display_help_system' => true
     ),
 
     /**

--- a/web/concrete/config/concrete.php
+++ b/web/concrete/config/concrete.php
@@ -492,7 +492,14 @@ return array(
          *
          * @var bool
          */
-        'toolbar_large_font' => false
+        'toolbar_large_font' => false,
+
+        /**
+         * Show help system
+         *
+         * @var bool
+         */
+        'display_help_system' => false
     ),
 
     /**

--- a/web/concrete/src/Application/Service/UserInterface/Help.php
+++ b/web/concrete/src/Application/Service/UserInterface/Help.php
@@ -7,12 +7,17 @@ use Concrete\Core\Application\Service\UserInterface\Help\MessageInterface;
 use Concrete\Core\Application\Service\UserInterface\Help\StandardManager;
 use User;
 use Core;
+use Config;
 
 class Help
 {
 
     public function display()
     {
+        if(!Config::get('concrete.accessibility.display_help_system')) {
+            return false;
+        }
+
         $args = func_get_args();
         $manager = null;
         $identifier = null;
@@ -39,6 +44,10 @@ class Help
 
     public function displayHelpDialogLauncher()
     {
+        if(!Config::get('concrete.accessibility.display_help_system')) {
+            return false;
+        }
+
         $html =<<<EOT
         <div class="ccm-notification-help-launcher">
             <a href="#" data-help-launch-dialog="main"><i class="fa fa-question-circle"></i></a>


### PR DESCRIPTION
In some scenarios we want to hide the help system. This PR adds a config setting to disable the help system (front-end & dashboard).

