### PR TITLE
Fix composer control required by default

### DIFF
--- a/web/concrete/src/Page/Type/Composer/Control/Control.php
+++ b/web/concrete/src/Page/Type/Composer/Control/Control.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Concrete\Core\Page\Type\Composer\Control;
 
 use Concrete\Core\Page\Type\Type;
 use Loader;
-use \Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\Object;
 use Page;
-use PageType;
 use Controller;
-use \Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayoutSet;
-use \Concrete\Core\Page\Type\Composer\FormLayoutSetControl as PageTypeComposerFormLayoutSetControl;
-use \Concrete\Core\Page\Type\Composer\Control\Type\Type as PageTypeComposerControlType;
+use Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayoutSet;
+use Concrete\Core\Page\Type\Composer\FormLayoutSetControl as PageTypeComposerFormLayoutSetControl;
+use Concrete\Core\Page\Type\Composer\Control\Type\Type as PageTypeComposerControlType;
 
 abstract class Control extends Object
 {
@@ -143,6 +143,7 @@ abstract class Control extends Object
 
     /**
      * @param PageTypeComposerFormLayoutSet $set
+     *
      * @return \Concrete\Core\Page\Type\Composer\FormLayoutSetControl
      */
     public function addToPageTypeComposerFormLayoutSet(PageTypeComposerFormLayoutSet $set)
@@ -158,7 +159,7 @@ abstract class Control extends Object
         }
         $controlType = $this->getPageTypeComposerControlTypeObject();
         $db->Execute('insert into PageTypeComposerFormLayoutSetControls (ptComposerFormLayoutSetID, ptComposerControlTypeID, ptComposerControlObject, ptComposerFormLayoutSetControlDisplayOrder, ptComposerFormLayoutSetControlRequired) values (?, ?, ?, ?, ?)', array(
-            $set->getPageTypeComposerFormLayoutSetID(), $controlType->getPageTypeComposerControlTypeID(), serialize($this), $displayOrder, $ptComposerFormLayoutSetControlRequired
+            $set->getPageTypeComposerFormLayoutSetID(), $controlType->getPageTypeComposerControlTypeID(), serialize($this), $displayOrder, $ptComposerFormLayoutSetControlRequired,
         ));
 
         return PageTypeComposerFormLayoutSetControl::getByID($db->Insert_ID());
@@ -191,8 +192,8 @@ abstract class Control extends Object
         return $controls;
     }
 
-    public function isPageTypeComposerControlRequiredByDefault() {
+    public function isPageTypeComposerControlRequiredByDefault()
+    {
         return $this->ptComposerControlRequiredByDefault;
     }
-
 }

--- a/web/concrete/src/Page/Type/Composer/Control/Control.php
+++ b/web/concrete/src/Page/Type/Composer/Control/Control.php
@@ -153,7 +153,7 @@ abstract class Control extends Object
             $displayOrder = 0;
         }
         $ptComposerFormLayoutSetControlRequired = 0;
-        if ($this->isPageTypeComposerControlRequiredByDefault) {
+        if ($this->isPageTypeComposerControlRequiredByDefault()) {
             $ptComposerFormLayoutSetControlRequired = 1;
         }
         $controlType = $this->getPageTypeComposerControlTypeObject();
@@ -189,6 +189,10 @@ abstract class Control extends Object
         }
 
         return $controls;
+    }
+
+    public function isPageTypeComposerControlRequiredByDefault() {
+        return $this->ptComposerControlRequiredByDefault;
     }
 
 }


### PR DESCRIPTION
In ComposerControl::addToPageTypeComposerFormLayoutSet we try to access an undefined class property called `isPageTypeComposerControlRequiredByDefault`.
If I'm not wrong, it should access the `ptComposerControlRequiredByDefault` property instead (and I wrapped it in a `isPageTypeComposerControlRequiredByDefault()` method).