### PR TITLE
'Package type' should be 'Package'

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/extend/install.php
+++ b/web/concrete/controllers/single_page/dashboard/extend/install.php
@@ -95,7 +95,7 @@ class Install extends DashboardPageController
 
     public function package_uninstalled()
     {
-        $this->set('message', t('The package type has been uninstalled.'));
+        $this->set('message', t('The package has been uninstalled.'));
     }
 
     public function install_package($package)


### PR DESCRIPTION
`The package type has been uninstalled`: what's a `package type`? I guess it should be just `package`